### PR TITLE
fix: label references

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,3 +1,5 @@
+workspace(name = "bazel_rules_nvc")
+
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
@@ -70,7 +72,7 @@ go_repository(
 
 gazelle_dependencies()
 
-load("//build/nvc:repositories.bzl", "nvc_repositories")
+load("@bazel_rules_nvc//build/nvc:repositories.bzl", "nvc_repositories")
 
 nvc_repositories()
 

--- a/build/nvc/BUILD.bazel
+++ b/build/nvc/BUILD.bazel
@@ -1,4 +1,4 @@
-load(":rules.bzl", "nvc_toolchain")
+load("@bazel_rules_nvc//build/nvc:rules.bzl", "nvc_toolchain")
 
 toolchain_type(name = "toolchain_type")
 

--- a/build/nvc/rules.bzl
+++ b/build/nvc/rules.bzl
@@ -6,9 +6,9 @@ NVCInfo = provider(
     ]
 )
 
-_NVC_TOOLCHAIN_TYPE = "//build/nvc:toolchain_type"
+_NVC_TOOLCHAIN_TYPE = "@bazel_rules_nvc//build/nvc:toolchain_type"
 
-_NVC_WRAPPER = Label("//build/nvc:nvc_wrapper")
+_NVC_WRAPPER = Label("@bazel_rules_nvc//build/nvc:nvc_wrapper")
 
 _VHDL_STANDARD = "2008"
 


### PR DESCRIPTION
Label references in macros must either be qualified by the repository name, or by using the `Label` constructor.

I didn't know this when I originally wrote the rules. So, now I'm correcting that.