### PR TITLE
Add `use_fst` attribute for FST waveform files

### DIFF
--- a/build/nvc/rules.md
+++ b/build/nvc/rules.md
@@ -180,7 +180,7 @@ Compiles VHDL source files into a library using NVC.
 <pre>
 load("@rules_nvc//build/nvc:rules.bzl", "vhdl_run")
 
-vhdl_run(<a href="#vhdl_run-name">name</a>, <a href="#vhdl_run-deps">deps</a>, <a href="#vhdl_run-args">args</a>, <a href="#vhdl_run-entity">entity</a>, <a href="#vhdl_run-standard">standard</a>, <a href="#vhdl_run-use_vcd">use_vcd</a>, <a href="#vhdl_run-use_fst">use_fst</a>)
+vhdl_run(<a href="#vhdl_run-name">name</a>, <a href="#vhdl_run-deps">deps</a>, <a href="#vhdl_run-args">args</a>, <a href="#vhdl_run-entity">entity</a>, <a href="#vhdl_run-standard">standard</a>, <a href="#vhdl_run-use_fst">use_fst</a>, <a href="#vhdl_run-use_vcd">use_vcd</a>)
 </pre>
 
 Simulates an elaborated VHDL design using NVC.
@@ -195,8 +195,8 @@ Simulates an elaborated VHDL design using NVC.
 | <a id="vhdl_run-args"></a>args |  A list of added command line args to use   | List of strings | optional |  `[]`  |
 | <a id="vhdl_run-entity"></a>entity |  The elaborated VHDL entity to simulate. This should be a `vhdl_elaborate` target.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
 | <a id="vhdl_run-standard"></a>standard |  The VHDL standard to use for simulation. Defaults to '2019'.   | String | optional |  `"2019"`  |
-| <a id="vhdl_run-use_vcd"></a>use_vcd |  A boolean indicating whether to generate a VCD (Value Change Dump) file for waveform viewing. Defaults to `True`.   | Boolean | optional |  `True`  |
 | <a id="vhdl_run-use_fst"></a>use_fst |  A boolean indicating whether to generate a FST file for waveform viewing. Defaults to `False`. Takes precedence over `use_vcd`.   | Boolean | optional |  `False`  |
+| <a id="vhdl_run-use_vcd"></a>use_vcd |  A boolean indicating whether to generate a VCD (Value Change Dump) file for waveform viewing. Defaults to `True`.   | Boolean | optional |  `True`  |
 
 
 <a id="vhdl_test"></a>

--- a/build/nvc/rules.md
+++ b/build/nvc/rules.md
@@ -82,7 +82,7 @@ Defines a prebuilt VHDL library, skipping analysis.
 <pre>
 load("@rules_nvc//build/nvc:rules.bzl", "produce_waveform")
 
-produce_waveform(<a href="#produce_waveform-name">name</a>, <a href="#produce_waveform-data">data</a>, <a href="#produce_waveform-args">args</a>, <a href="#produce_waveform-simulation">simulation</a>)
+produce_waveform(<a href="#produce_waveform-name">name</a>, <a href="#produce_waveform-data">data</a>, <a href="#produce_waveform-args">args</a>, <a href="#produce_waveform-simulation">simulation</a>, <a href="#produce_waveform-use_fst">use_fst</a>)
 </pre>
 
 Produces a waveform file (VCD) from a VHDL simulation run.
@@ -96,6 +96,7 @@ Produces a waveform file (VCD) from a VHDL simulation run.
 | <a id="produce_waveform-data"></a>data |  Data files required for the simulation.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="produce_waveform-args"></a>args |  Additional command-line arguments to pass to the simulation.   | List of strings | optional |  `[]`  |
 | <a id="produce_waveform-simulation"></a>simulation |  The simulation target (`vhdl_run`) to execute.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
+| <a id="produce_waveform-use_fst"></a>use_fst |  A boolean indicating whether to expect an FST file instead of VCD file. Defaults to `False`.   | Boolean | optional |  `False`  |
 
 
 <a id="verilog_library"></a>
@@ -179,7 +180,7 @@ Compiles VHDL source files into a library using NVC.
 <pre>
 load("@rules_nvc//build/nvc:rules.bzl", "vhdl_run")
 
-vhdl_run(<a href="#vhdl_run-name">name</a>, <a href="#vhdl_run-deps">deps</a>, <a href="#vhdl_run-args">args</a>, <a href="#vhdl_run-entity">entity</a>, <a href="#vhdl_run-standard">standard</a>, <a href="#vhdl_run-use_vcd">use_vcd</a>)
+vhdl_run(<a href="#vhdl_run-name">name</a>, <a href="#vhdl_run-deps">deps</a>, <a href="#vhdl_run-args">args</a>, <a href="#vhdl_run-entity">entity</a>, <a href="#vhdl_run-standard">standard</a>, <a href="#vhdl_run-use_vcd">use_vcd</a>, <a href="#vhdl_run-use_fst">use_fst</a>)
 </pre>
 
 Simulates an elaborated VHDL design using NVC.
@@ -195,6 +196,7 @@ Simulates an elaborated VHDL design using NVC.
 | <a id="vhdl_run-entity"></a>entity |  The elaborated VHDL entity to simulate. This should be a `vhdl_elaborate` target.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
 | <a id="vhdl_run-standard"></a>standard |  The VHDL standard to use for simulation. Defaults to '2019'.   | String | optional |  `"2019"`  |
 | <a id="vhdl_run-use_vcd"></a>use_vcd |  A boolean indicating whether to generate a VCD (Value Change Dump) file for waveform viewing. Defaults to `True`.   | Boolean | optional |  `True`  |
+| <a id="vhdl_run-use_fst"></a>use_fst |  A boolean indicating whether to generate a FST file for waveform viewing. Defaults to `False`. Takes precedence over `use_vcd`.   | Boolean | optional |  `False`  |
 
 
 <a id="vhdl_test"></a>

--- a/internal/produce_waveform.bzl
+++ b/internal/produce_waveform.bzl
@@ -12,7 +12,12 @@ def _produce_waveform(ctx):
     for target in ctx.attr.data:
         for file in target.files.to_list():
             data_files += [file]
-    output_file = ctx.actions.declare_file("{}.vcd".format(ctx.attr.name))
+
+    ext = "vcd"
+    if ctx.attr.use_fst:
+        ext = "fst"
+
+    output_file = ctx.actions.declare_file("{}.{}".format(ctx.attr.name, ext))
     runfiles = ctx.runfiles(files=[output_file] + data_files)
     sim = ctx.executable.simulation
     ctx.actions.run(
@@ -48,6 +53,10 @@ produce_waveform = rule(
         ),
         "args": attr.string_list(
             doc = "Additional command-line arguments to pass to the simulation.",
+        ),
+        "use_fst": attr.bool(
+            default = False,
+            doc = "A boolean indicating whether to expect an FST file instead of VCD file. Defaults to `False`.",
         ),
     },
 )

--- a/internal/produce_waveform.md
+++ b/internal/produce_waveform.md
@@ -9,7 +9,7 @@
 <pre>
 load("@rules_nvc//internal:produce_waveform.bzl", "produce_waveform")
 
-produce_waveform(<a href="#produce_waveform-name">name</a>, <a href="#produce_waveform-data">data</a>, <a href="#produce_waveform-args">args</a>, <a href="#produce_waveform-simulation">simulation</a>)
+produce_waveform(<a href="#produce_waveform-name">name</a>, <a href="#produce_waveform-data">data</a>, <a href="#produce_waveform-args">args</a>, <a href="#produce_waveform-simulation">simulation</a>, <a href="#produce_waveform-use_fst">use_fst</a>)
 </pre>
 
 Produces a waveform file (VCD) from a VHDL simulation run.
@@ -23,5 +23,6 @@ Produces a waveform file (VCD) from a VHDL simulation run.
 | <a id="produce_waveform-data"></a>data |  Data files required for the simulation.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="produce_waveform-args"></a>args |  Additional command-line arguments to pass to the simulation.   | List of strings | optional |  `[]`  |
 | <a id="produce_waveform-simulation"></a>simulation |  The simulation target (`vhdl_run`) to execute.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
+| <a id="produce_waveform-use_fst"></a>use_fst |  A boolean indicating whether to expect an FST file instead of VCD file. Defaults to `False`.   | Boolean | optional |  `False`  |
 
 

--- a/internal/vhdl_run.bzl
+++ b/internal/vhdl_run.bzl
@@ -33,11 +33,17 @@ def _vhdl_run(ctx):
 
     work_library_file = get_single_file_from(ctx.attr.entity)
 
+    ext = "vcd"
+    if ctx.attr.use_fst:
+        ext = "fst"
+
     wave_file = ctx.actions.declare_file(
-        "{}.vcd".format(ctx.attr.name))
+        "{}.{}".format(ctx.attr.name, ext))
 
     format = []
-    if ctx.attr.use_vcd:
+    if ctx.attr.use_fst:
+        format = [ "--format=fst" ]
+    elif ctx.attr.use_vcd:
         format = [ "--format=vcd" ]
 
     elaborate_provider = ctx.attr.entity[ElaborateProvider]
@@ -100,6 +106,10 @@ vhdl_run = rule(
         "use_vcd": attr.bool(
             default = True,
             doc = "A boolean indicating whether to generate a VCD (Value Change Dump) file for waveform viewing. Defaults to `True`.",
+        ),
+        "use_fst": attr.bool(
+            default = False,
+            doc = "A boolean indicating whether to generate a FST file for waveform viewing. Defaults to `False`. Takes precedence over `use_vcd`.",
         ),
         "args": attr.string_list(
             doc = "A list of added command line args to use",

--- a/internal/vhdl_run.md
+++ b/internal/vhdl_run.md
@@ -9,7 +9,7 @@
 <pre>
 load("@rules_nvc//internal:vhdl_run.bzl", "vhdl_run")
 
-vhdl_run(<a href="#vhdl_run-name">name</a>, <a href="#vhdl_run-deps">deps</a>, <a href="#vhdl_run-args">args</a>, <a href="#vhdl_run-entity">entity</a>, <a href="#vhdl_run-standard">standard</a>, <a href="#vhdl_run-use_vcd">use_vcd</a>)
+vhdl_run(<a href="#vhdl_run-name">name</a>, <a href="#vhdl_run-deps">deps</a>, <a href="#vhdl_run-args">args</a>, <a href="#vhdl_run-entity">entity</a>, <a href="#vhdl_run-standard">standard</a>, <a href="#vhdl_run-use_vcd">use_vcd</a>, <a href="#vhdl_run-use_fst">use_fst</a>)
 </pre>
 
 Simulates an elaborated VHDL design using NVC.
@@ -25,5 +25,6 @@ Simulates an elaborated VHDL design using NVC.
 | <a id="vhdl_run-entity"></a>entity |  The elaborated VHDL entity to simulate. This should be a `vhdl_elaborate` target.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
 | <a id="vhdl_run-standard"></a>standard |  The VHDL standard to use for simulation. Defaults to '2019'.   | String | optional |  `"2019"`  |
 | <a id="vhdl_run-use_vcd"></a>use_vcd |  A boolean indicating whether to generate a VCD (Value Change Dump) file for waveform viewing. Defaults to `True`.   | Boolean | optional |  `True`  |
+| <a id="vhdl_run-use_fst"></a>use_fst |  A boolean indicating whether to generate a FST file for waveform viewing. Defaults to `False`. Takes precedence over `use_vcd`.   | Boolean | optional |  `False`  |
 
 

--- a/internal/vhdl_run.md
+++ b/internal/vhdl_run.md
@@ -9,7 +9,7 @@
 <pre>
 load("@rules_nvc//internal:vhdl_run.bzl", "vhdl_run")
 
-vhdl_run(<a href="#vhdl_run-name">name</a>, <a href="#vhdl_run-deps">deps</a>, <a href="#vhdl_run-args">args</a>, <a href="#vhdl_run-entity">entity</a>, <a href="#vhdl_run-standard">standard</a>, <a href="#vhdl_run-use_vcd">use_vcd</a>, <a href="#vhdl_run-use_fst">use_fst</a>)
+vhdl_run(<a href="#vhdl_run-name">name</a>, <a href="#vhdl_run-deps">deps</a>, <a href="#vhdl_run-args">args</a>, <a href="#vhdl_run-entity">entity</a>, <a href="#vhdl_run-standard">standard</a>, <a href="#vhdl_run-use_fst">use_fst</a>, <a href="#vhdl_run-use_vcd">use_vcd</a>)
 </pre>
 
 Simulates an elaborated VHDL design using NVC.
@@ -24,7 +24,7 @@ Simulates an elaborated VHDL design using NVC.
 | <a id="vhdl_run-args"></a>args |  A list of added command line args to use   | List of strings | optional |  `[]`  |
 | <a id="vhdl_run-entity"></a>entity |  The elaborated VHDL entity to simulate. This should be a `vhdl_elaborate` target.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
 | <a id="vhdl_run-standard"></a>standard |  The VHDL standard to use for simulation. Defaults to '2019'.   | String | optional |  `"2019"`  |
-| <a id="vhdl_run-use_vcd"></a>use_vcd |  A boolean indicating whether to generate a VCD (Value Change Dump) file for waveform viewing. Defaults to `True`.   | Boolean | optional |  `True`  |
 | <a id="vhdl_run-use_fst"></a>use_fst |  A boolean indicating whether to generate a FST file for waveform viewing. Defaults to `False`. Takes precedence over `use_vcd`.   | Boolean | optional |  `False`  |
+| <a id="vhdl_run-use_vcd"></a>use_vcd |  A boolean indicating whether to generate a VCD (Value Change Dump) file for waveform viewing. Defaults to `True`.   | Boolean | optional |  `True`  |
 
 

--- a/nvc/rules.md
+++ b/nvc/rules.md
@@ -54,7 +54,7 @@ Defines the NVC toolchain, linking to the NVC analyzer and standard library.
 <pre>
 load("@rules_nvc//nvc:rules.bzl", "produce_waveform")
 
-produce_waveform(<a href="#produce_waveform-name">name</a>, <a href="#produce_waveform-data">data</a>, <a href="#produce_waveform-args">args</a>, <a href="#produce_waveform-simulation">simulation</a>)
+produce_waveform(<a href="#produce_waveform-name">name</a>, <a href="#produce_waveform-data">data</a>, <a href="#produce_waveform-args">args</a>, <a href="#produce_waveform-simulation">simulation</a>, <a href="#produce_waveform-use_fst">use_fst</a>)
 </pre>
 
 Produces a waveform file (VCD) from a VHDL simulation run.
@@ -68,6 +68,7 @@ Produces a waveform file (VCD) from a VHDL simulation run.
 | <a id="produce_waveform-data"></a>data |  Data files required for the simulation.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="produce_waveform-args"></a>args |  Additional command-line arguments to pass to the simulation.   | List of strings | optional |  `[]`  |
 | <a id="produce_waveform-simulation"></a>simulation |  The simulation target (`vhdl_run`) to execute.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
+| <a id="produce_waveform-use_fst"></a>use_fst |  A boolean indicating whether to expect an FST file instead of VCD file. Defaults to `False`.   | Boolean | optional |  `False`  |
 
 
 <a id="vhdl_elaborate"></a>
@@ -124,7 +125,7 @@ Compiles VHDL source files into a library using NVC.
 <pre>
 load("@rules_nvc//nvc:rules.bzl", "vhdl_run")
 
-vhdl_run(<a href="#vhdl_run-name">name</a>, <a href="#vhdl_run-deps">deps</a>, <a href="#vhdl_run-args">args</a>, <a href="#vhdl_run-entity">entity</a>, <a href="#vhdl_run-standard">standard</a>, <a href="#vhdl_run-use_vcd">use_vcd</a>)
+vhdl_run(<a href="#vhdl_run-name">name</a>, <a href="#vhdl_run-deps">deps</a>, <a href="#vhdl_run-args">args</a>, <a href="#vhdl_run-entity">entity</a>, <a href="#vhdl_run-standard">standard</a>, <a href="#vhdl_run-use_vcd">use_vcd</a>, <a href="#vhdl_run-use_fst">use_fst</a>)
 </pre>
 
 Simulates an elaborated VHDL design using NVC.
@@ -140,6 +141,7 @@ Simulates an elaborated VHDL design using NVC.
 | <a id="vhdl_run-entity"></a>entity |  The elaborated VHDL entity to simulate. This should be a `vhdl_elaborate` target.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
 | <a id="vhdl_run-standard"></a>standard |  The VHDL standard to use for simulation. Defaults to '2019'.   | String | optional |  `"2019"`  |
 | <a id="vhdl_run-use_vcd"></a>use_vcd |  A boolean indicating whether to generate a VCD (Value Change Dump) file for waveform viewing. Defaults to `True`.   | Boolean | optional |  `True`  |
+| <a id="vhdl_run-use_fst"></a>use_fst |  A boolean indicating whether to generate a FST file for waveform viewing. Defaults to `False`. Takes precedence over `use_vcd`.   | Boolean | optional |  `False`  |
 
 
 <a id="vhdl_test"></a>

--- a/nvc/rules.md
+++ b/nvc/rules.md
@@ -125,7 +125,7 @@ Compiles VHDL source files into a library using NVC.
 <pre>
 load("@rules_nvc//nvc:rules.bzl", "vhdl_run")
 
-vhdl_run(<a href="#vhdl_run-name">name</a>, <a href="#vhdl_run-deps">deps</a>, <a href="#vhdl_run-args">args</a>, <a href="#vhdl_run-entity">entity</a>, <a href="#vhdl_run-standard">standard</a>, <a href="#vhdl_run-use_vcd">use_vcd</a>, <a href="#vhdl_run-use_fst">use_fst</a>)
+vhdl_run(<a href="#vhdl_run-name">name</a>, <a href="#vhdl_run-deps">deps</a>, <a href="#vhdl_run-args">args</a>, <a href="#vhdl_run-entity">entity</a>, <a href="#vhdl_run-standard">standard</a>, <a href="#vhdl_run-use_fst">use_fst</a>, <a href="#vhdl_run-use_vcd">use_vcd</a>)
 </pre>
 
 Simulates an elaborated VHDL design using NVC.
@@ -140,8 +140,8 @@ Simulates an elaborated VHDL design using NVC.
 | <a id="vhdl_run-args"></a>args |  A list of added command line args to use   | List of strings | optional |  `[]`  |
 | <a id="vhdl_run-entity"></a>entity |  The elaborated VHDL entity to simulate. This should be a `vhdl_elaborate` target.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
 | <a id="vhdl_run-standard"></a>standard |  The VHDL standard to use for simulation. Defaults to '2019'.   | String | optional |  `"2019"`  |
-| <a id="vhdl_run-use_vcd"></a>use_vcd |  A boolean indicating whether to generate a VCD (Value Change Dump) file for waveform viewing. Defaults to `True`.   | Boolean | optional |  `True`  |
 | <a id="vhdl_run-use_fst"></a>use_fst |  A boolean indicating whether to generate a FST file for waveform viewing. Defaults to `False`. Takes precedence over `use_vcd`.   | Boolean | optional |  `False`  |
+| <a id="vhdl_run-use_vcd"></a>use_vcd |  A boolean indicating whether to generate a VCD (Value Change Dump) file for waveform viewing. Defaults to `True`.   | Boolean | optional |  `True`  |
 
 
 <a id="vhdl_test"></a>


### PR DESCRIPTION
This submission implements support for generating `.fst` waveform files in `rules_nvc`, addressing issue #43. It achieves this by adding a new `use_fst` attribute to both `vhdl_run` and `produce_waveform` rules, which modifies the output file extension and adds the corresponding `--format=fst` option to the NVC simulator execution. The generated documentation in `.md` files was also updated via Stardoc.

---
*PR created automatically by Jules for task [14738902265424181801](https://jules.google.com/task/14738902265424181801) started by @filmil*