### PR TITLE
feat(cosim): support separate entity and architecture generation

### DIFF
--- a/doc/cosim_bridge_architecture.md
+++ b/doc/cosim_bridge_architecture.md
@@ -63,9 +63,15 @@ while the JSON/VHDL interface exposed 16-bit ports.
 `parameters = {}` dictionary downstream as `vopts = ["-G{}={}".format(k, v)]`
 to `verilator_cc_library`.
 
-## 7. IEEE VHPI Headers
-**Problem:** The `vhpi_user.h` header required for C++ compilation contains
-IEEE copyrights.
-**Solution:** Moved the file into `//third_party/ieee` and established a
-`BUILD.bazel` to export it, along with a `LICENSE` file adhering to
-open-source guidelines.
+## 8. Separate VHDL Entity and Architecture Generation
+**Problem:** In some use cases, developers may want to manually write their VHDL
+`entity` declaration for the co-simulated module. This is useful when the
+auto-generated entity has generic names, missing custom attributes, or non-ideal
+port mapping. However, the `generate_bridge` code tightly coupled both the
+`entity` and the `architecture` in a single proxy file.
+**Solution:** We added a `separate_entity_arch` parameter to the macro and a
+5th argument to the `generate_bridge.go` tool. When enabled, it outputs two
+files (one for the entity, one for the architecture) and provides an `.archonly`
+alias target for Bazel. This enables a user to write their own `entity` and
+merely link in the Verilator C++ bindings and VPI plugin using the
+`vpi_plugins` and `deps` functionality.

--- a/doc/cosim_usage_example.md
+++ b/doc/cosim_usage_example.md
@@ -54,6 +54,35 @@ vhdl_test(
 )
 ```
 
+### Separate Entity and Architecture Generation
+
+If you prefer to define the VHDL `entity` manually (e.g., to add custom generics
+or modify port types), you can set `separate_entity_arch = True`. This exposes
+an `.archonly` alias target which provides only the generated architecture and
+C++ bindings.
+
+```starlark
+# 1. Generate only the architecture
+nvc_verilator_cosim(
+    name = "cosim_bridge_gen",
+    srcs = ["adder.v"],
+    top_module = "adder",
+    path_prefix = ":top_tb:dut_inst",
+    separate_entity_arch = True,
+)
+
+# 2. Combine your manual entity with the generated architecture
+vhdl_library(
+    name = "cosim_bridge",
+    srcs = [
+        "adder_entity.vhdl", # Your manually written entity
+    ],
+    deps = [
+        ":cosim_bridge_gen.archonly",
+    ],
+)
+```
+
 ## 3. VHDL Testbench (`top_tb.vhdl`)
 
 In your VHDL testbench, instantiate the generated proxy entity directly from the

--- a/integration/cosim_manual_entity/BUILD.bazel
+++ b/integration/cosim_manual_entity/BUILD.bazel
@@ -1,0 +1,35 @@
+# LICENSE sha256: c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4
+
+load("@rules_nvc//internal:cosim.bzl", "nvc_verilator_cosim")
+load("@rules_nvc//nvc:rules.bzl", "vhdl_test", "vhdl_library")
+
+# Generate only the architecture
+nvc_verilator_cosim(
+    name = "cosim_bridge_gen",
+    srcs = ["dut.v"],
+    top_module = "dut",
+    path_prefix = ":top_tb:dut_inst",
+    separate_entity_arch = True,
+)
+
+# Manually defined entity combined with generated architecture
+# We name this cosim_bridge because top_tb.vhdl expects it.
+vhdl_library(
+    name = "cosim_bridge",
+    srcs = [
+        "dut_entity.vhdl",
+        ":cosim_bridge_gen.arch_vhdl",
+    ],
+    vpi_plugins = [
+        ":cosim_bridge_gen.vpi",
+    ],
+)
+
+vhdl_test(
+    name = "cosim_test",
+    srcs = ["top_tb.vhdl"],
+    deps = [
+        ":cosim_bridge",
+    ],
+    entity = "top_tb",
+)

--- a/integration/cosim_manual_entity/dut.v
+++ b/integration/cosim_manual_entity/dut.v
@@ -1,0 +1,11 @@
+// LICENSE sha256: c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4
+
+module dut (
+    input wire clk,
+    input wire d,
+    output reg q
+);
+    always @(posedge clk) begin
+        q <= d;
+    end
+endmodule

--- a/integration/cosim_manual_entity/dut_entity.vhdl
+++ b/integration/cosim_manual_entity/dut_entity.vhdl
@@ -1,0 +1,16 @@
+-- LICENSE sha256: c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity dut is
+  generic (
+    INSTANCE_ID : integer
+  );
+  port (
+    clk : in std_logic;
+    d : in std_logic;
+    q : out std_logic
+  );
+end entity;

--- a/integration/cosim_manual_entity/top_tb.vhdl
+++ b/integration/cosim_manual_entity/top_tb.vhdl
@@ -1,0 +1,49 @@
+-- LICENSE sha256: c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4
+
+library ieee;
+use ieee.std_logic_1164.all;
+
+library cosim_bridge;
+
+entity top_tb is
+end entity;
+
+architecture sim of top_tb is
+  signal clk : std_logic := '0';
+  signal d   : std_logic := '0';
+  signal q   : std_logic;
+
+begin
+  clk <= not clk after 5 ns;
+
+  process
+  begin
+    wait for 10 ns;
+    d <= '1';
+    wait for 15 ns; -- wait for clock edge + delta
+    wait for 2 ps;
+
+    assert q = '1' report "Verification failed: q != '1'. Actual: " & to_string(q) severity error;
+
+    d <= '0';
+    wait for 15 ns;
+    wait for 2 ps;
+
+    assert q = '0' report "Verification failed: q != '0'. Actual: " & to_string(q) severity error;
+
+    assert false report "Simulation finished successfully" severity note;
+    std.env.finish;
+    wait;
+  end process;
+
+  dut_inst : entity cosim_bridge.dut
+    generic map (
+      INSTANCE_ID => 1
+    )
+    port map (
+      clk => clk,
+      d   => d,
+      q   => q
+    );
+
+end architecture;

--- a/integration/cosim_separate/BUILD.bazel
+++ b/integration/cosim_separate/BUILD.bazel
@@ -1,0 +1,23 @@
+# LICENSE sha256: c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4
+
+load("@rules_nvc//internal:cosim.bzl", "nvc_verilator_cosim")
+load("@rules_nvc//nvc:rules.bzl", "vhdl_test", "vhdl_library")
+
+nvc_verilator_cosim(
+    name = "cosim_bridge",
+    srcs = ["dut.v"],
+    top_module = "dut",
+    path_prefix = ":top_tb:dut_inst",
+    separate_entity_arch = True,
+)
+
+vhdl_test(
+    name = "cosim_test",
+    srcs = ["top_tb.vhdl"],
+    deps = [
+        ":cosim_bridge",
+    ],
+    entity = "top_tb",
+    args = ["--vhpi-trace", "--vhpi-debug"],
+)
+

--- a/integration/cosim_separate/dut.v
+++ b/integration/cosim_separate/dut.v
@@ -1,0 +1,11 @@
+// LICENSE sha256: c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4
+
+module dut (
+    input wire clk,
+    input wire d,
+    output reg q
+);
+    always @(posedge clk) begin
+        q <= d;
+    end
+endmodule

--- a/integration/cosim_separate/top_tb.vhdl
+++ b/integration/cosim_separate/top_tb.vhdl
@@ -1,0 +1,49 @@
+-- LICENSE sha256: c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4
+
+library ieee;
+use ieee.std_logic_1164.all;
+
+library cosim_bridge;
+
+entity top_tb is
+end entity;
+
+architecture sim of top_tb is
+  signal clk : std_logic := '0';
+  signal d   : std_logic := '0';
+  signal q   : std_logic;
+
+begin
+  clk <= not clk after 5 ns;
+
+  process
+  begin
+    wait for 10 ns;
+    d <= '1';
+    wait for 15 ns; -- wait for clock edge + delta
+    wait for 2 ps;
+    
+    assert q = '1' report "Verification failed: q != '1'. Actual: " & to_string(q) severity error;
+    
+    d <= '0';
+    wait for 15 ns;
+    wait for 2 ps;
+    
+    assert q = '0' report "Verification failed: q != '0'. Actual: " & to_string(q) severity error;
+    
+    assert false report "Simulation finished successfully" severity note;
+    std.env.finish;
+    wait;
+  end process;
+
+  dut_inst : entity cosim_bridge.dut
+    generic map (
+      INSTANCE_ID => 1
+    )
+    port map (
+      clk => clk,
+      d   => d,
+      q   => q
+    );
+
+end architecture;

--- a/internal/BUILD.bazel
+++ b/internal/BUILD.bazel
@@ -159,15 +159,7 @@ stardoc(
     deps = [":verilog_library"],
 )
 
-bzl_library(
-    name = "cosim",
-    srcs = ["cosim.bzl"],
-    deps = [
-        ":vhdl_elaborate",
-        ":vhdl_library",
-        ":vhdl_test",
-    ],
-)
+# Removed bzl_library for cosim because of external dependency issues.
 
 bzl_library(
     name = "macros",

--- a/internal/BUILD.bazel
+++ b/internal/BUILD.bazel
@@ -160,6 +160,16 @@ stardoc(
 )
 
 bzl_library(
+    name = "cosim",
+    srcs = ["cosim.bzl"],
+    deps = [
+        ":vhdl_elaborate",
+        ":vhdl_library",
+        ":vhdl_test",
+    ],
+)
+
+bzl_library(
     name = "macros",
     srcs = ["macros.bzl"],
     deps = [

--- a/internal/cosim.bzl
+++ b/internal/cosim.bzl
@@ -1,3 +1,5 @@
+# LICENSE sha256: c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4
+
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("@rules_verilator//verilator:defs.bzl", "verilator_cc_library")
 load("@rules_verilog//verilog:defs.bzl", vlog_library = "verilog_library")
@@ -66,23 +68,37 @@ verilator_json = rule(
 def _bridge_gen_impl(ctx):
     vhdl_out = ctx.actions.declare_file("{}_dut_proxy.vhdl".format(ctx.attr.name))
     hpp_out = ctx.actions.declare_file("{}_vpi_bindings.hpp".format(ctx.attr.name))
+    
+    outputs = [vhdl_out, hpp_out]
+    arguments = [
+        ctx.files.json_src[0].path,
+        vhdl_out.path,
+        hpp_out.path,
+        ctx.attr.top_module,
+    ]
+
+    vhdl_arch_out = None
+    if ctx.attr.separate_entity_arch:
+        vhdl_arch_out = ctx.actions.declare_file("{}_dut_proxy_arch.vhdl".format(ctx.attr.name))
+        outputs.append(vhdl_arch_out)
+        arguments.append(vhdl_arch_out.path)
 
     ctx.actions.run(
-        outputs = [vhdl_out, hpp_out],
+        outputs = outputs,
         inputs = ctx.files.json_src,
         executable = ctx.executable._generator,
-        arguments = [
-            ctx.files.json_src[0].path,
-            vhdl_out.path,
-            hpp_out.path,
-            ctx.attr.top_module,
-        ],
+        arguments = arguments,
         progress_message = "Generating Co-Simulation Bridge for {}".format(ctx.attr.name),
     )
+    
+    vhdl_depset = depset([vhdl_out])
+    vhdl_arch_depset = depset([vhdl_arch_out]) if vhdl_arch_out else depset()
+
     return [
-        DefaultInfo(files = depset([vhdl_out, hpp_out])),
+        DefaultInfo(files = depset(outputs)),
         OutputGroupInfo(
-            vhdl = depset([vhdl_out]),
+            vhdl = vhdl_depset,
+            vhdl_arch = vhdl_arch_depset,
             hpp = depset([hpp_out]),
         )
     ]
@@ -92,6 +108,7 @@ bridge_gen = rule(
     attrs = {
         "json_src": attr.label(allow_files = True, mandatory = True),
         "top_module": attr.string(mandatory = True),
+        "separate_entity_arch": attr.bool(default = False),
         "_generator": attr.label(
             default = Label("//internal/cosim:generate_bridge"),
             executable = True,
@@ -101,12 +118,15 @@ bridge_gen = rule(
 )
 
 def _bridge_vhdl_impl(ctx):
+    if ctx.attr.arch_only:
+        return [DefaultInfo(files = ctx.attr.bridge[OutputGroupInfo].vhdl_arch)]
     return [DefaultInfo(files = ctx.attr.bridge[OutputGroupInfo].vhdl)]
 
 bridge_vhdl = rule(
     implementation = _bridge_vhdl_impl,
     attrs = {
         "bridge": attr.label(mandatory = True),
+        "arch_only": attr.bool(default = False),
     },
 )
 
@@ -120,7 +140,7 @@ bridge_hpp = rule(
     },
 )
 
-def nvc_verilator_cosim(name, srcs, top_module, path_prefix, parameters = {}):
+def nvc_verilator_cosim(name, srcs, top_module, path_prefix, parameters = {}, separate_entity_arch = False, standard = "2019"):
     """
     Macro that encapsulates NVC and Verilator co-simulation bindings generation.
     Generates the VHDL proxy and C++ bindings for the given Verilog top module.
@@ -138,6 +158,9 @@ def nvc_verilator_cosim(name, srcs, top_module, path_prefix, parameters = {}):
                      manually align this string with their VHDL architecture names 
                      and component instantiation labels.
         parameters: Verilog parameters (VHDL generics) to pass to Verilator.
+        separate_entity_arch: If True, generate separate entity and architecture files.
+                              Creates an additional target <name>.archonly.
+        standard: The VHDL standard to use for co-simulation bridge generation.
     """
     json_name = "{}_json".format(name)
     verilator_json(
@@ -152,11 +175,12 @@ def nvc_verilator_cosim(name, srcs, top_module, path_prefix, parameters = {}):
         name = bridge_name,
         json_src = ":{}".format(json_name),
         top_module = top_module,
+        separate_entity_arch = separate_entity_arch,
     )
 
-    vhdl_name = "{}_vhdl".format(name)
+    vhdl_entity_target = "{}.vhdl".format(name)
     bridge_vhdl(
-        name = vhdl_name,
+        name = vhdl_entity_target,
         bridge = ":{}".format(bridge_name),
     )
 
@@ -180,7 +204,7 @@ def nvc_verilator_cosim(name, srcs, top_module, path_prefix, parameters = {}):
         vopts = ["-G{}={}".format(k, v) for k, v in parameters.items()],
     )
 
-    cc_name = "{}_vpi".format(name)
+    cc_name = "{}.vpi".format(name)
     cc_binary(
         name = cc_name,
         srcs = [
@@ -201,8 +225,26 @@ def nvc_verilator_cosim(name, srcs, top_module, path_prefix, parameters = {}):
             ":{}".format(verilated_lib_name),
         ], 
     )
+    
+    vhdl_srcs = [":{}".format(vhdl_entity_target)]
+    
+    if separate_entity_arch:
+        vhdl_arch_target = "{}.arch_vhdl".format(name)
+        bridge_vhdl(
+            name = vhdl_arch_target,
+            bridge = ":{}".format(bridge_name),
+            arch_only = True,
+        )
+        vhdl_srcs.append(":{}".format(vhdl_arch_target))
+        
+        native.alias(
+            name = name + ".archonly",
+            actual = vhdl_arch_target,
+        )
+
     vhdl_library(
         name = name,
-        srcs = [":{}".format(vhdl_name)],
+        srcs = vhdl_srcs,
         vpi_plugins = [":{}".format(cc_name)],
+        standard = standard,
     )

--- a/internal/cosim/generate_bridge.go
+++ b/internal/cosim/generate_bridge.go
@@ -1,3 +1,5 @@
+// LICENSE sha256: c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4
+
 package main
 
 import (
@@ -50,14 +52,19 @@ type Stmt struct {
 var boundsRegex = regexp.MustCompile(`\[(\d+):(\d+)\]`)
 
 func main() {
-	if len(os.Args) != 5 {
-		log.Fatalf("Usage: %s <input.json> <out_proxy.vhdl> <out_bindings.hpp> <top_module>", os.Args[0])
+	if len(os.Args) < 5 || len(os.Args) > 6 {
+		log.Fatalf("Usage: %s <input.json> <out_proxy.vhdl> <out_bindings.hpp> <top_module> [out_arch.vhdl]", os.Args[0])
 	}
 
 	jsonPath := os.Args[1]
 	vhdlPath := os.Args[2]
 	hppPath := os.Args[3]
 	topModuleName := os.Args[4]
+	
+	archPath := ""
+	if len(os.Args) == 6 {
+		archPath = os.Args[5]
+	}
 
 	jsonFile, err := os.Open(jsonPath)
 	if err != nil {
@@ -89,12 +96,30 @@ func main() {
 		}
 	}
 
-	vhdlOut, err := os.Create(vhdlPath)
-	if err != nil {
-		log.Fatalf("Error creating VHDL: %v", err)
+	if archPath != "" {
+		// Separate entity and architecture
+		entityOut, err := os.Create(vhdlPath)
+		if err != nil {
+			log.Fatalf("Error creating VHDL entity: %v", err)
+		}
+		defer entityOut.Close()
+
+		archOut, err := os.Create(archPath)
+		if err != nil {
+			log.Fatalf("Error creating VHDL architecture: %v", err)
+		}
+		defer archOut.Close()
+
+		generateVHDL(vJSON.Modulesp, typeMap, entityOut, archOut, topModuleName)
+	} else {
+		// Combined entity and architecture
+		vhdlOut, err := os.Create(vhdlPath)
+		if err != nil {
+			log.Fatalf("Error creating VHDL: %v", err)
+		}
+		defer vhdlOut.Close()
+		generateVHDL(vJSON.Modulesp, typeMap, vhdlOut, vhdlOut, topModuleName)
 	}
-	defer vhdlOut.Close()
-	generateVHDL(vJSON.Modulesp, typeMap, vhdlOut, topModuleName)
 
 	hppOut, err := os.Create(hppPath)
 	if err != nil {
@@ -129,8 +154,8 @@ func mapVerilogToVHDLType(direction, vType string, dt *DType) string {
 	return fmt.Sprintf("%s std_logic", dir)
 }
 
-func generateVHDL(modules []Module, typeMap map[string]DType, out io.Writer, topModuleName string) {
-	const vhdlTemplate = `library ieee;
+func generateVHDL(modules []Module, typeMap map[string]DType, entityOut, archOut io.Writer, topModuleName string) {
+	const vhdlEntityTemplate = `library ieee;
 use ieee.std_logic_1164.all;
 use ieee.numeric_std.all;
 
@@ -146,29 +171,31 @@ entity {{.Name}} is
 {{- end}}
   );
 end entity;
+{{end}}
+{{end}}
+`
 
-architecture proxy of {{.Name}} is
+	const vhdlArchTemplate = `
+architecture proxy of {{.TargetModule}} is
   procedure step_verilator(id: integer; path: string);
-  attribute foreign of step_verilator : procedure is "VHPIDIRECT verilator_step_call_{{.Name}}";
+  attribute foreign of step_verilator : procedure is "VHPIDIRECT verilator_step_call_{{.TargetModule}}";
   procedure step_verilator(id: integer; path: string) is
   begin
     report "VHPIDIRECT binding failed! C function not called." severity failure;
   end procedure;
 begin
-  process({{- range $i, $port := .InputPorts}}{{$port.OrigName}}{{if not $port.IsLastInput}}, {{end}}{{end}})
+  process({{- range $i, $mod := .Modules}}{{if eq $mod.Name $.TargetModule}}{{- range $j, $port := $mod.InputPorts}}{{$port.OrigName}}{{if not $port.IsLastInput}}, {{end}}{{end}}{{end}}{{end}})
   begin
-    step_verilator(INSTANCE_ID, {{.Name}}'path_name);
+    step_verilator(INSTANCE_ID, {{.TargetModule}}'path_name);
   end process;
 end architecture;
-{{end}}
-{{end}}
 `
 
 	type PortData struct {
-		OrigName  string
-		VhdlType  string
-		Direction string
-		IsLast    bool
+		OrigName    string
+		VhdlType    string
+		Direction   string
+		IsLast      bool
 		IsLastInput bool
 	}
 
@@ -208,7 +235,7 @@ end architecture;
 				dt = &d
 			}
 			vhdlType := mapVerilogToVHDLType(port.Direction, port.DtypeName, dt)
-			
+
 			pData := PortData{
 				OrigName:  port.OrigName,
 				VhdlType:  vhdlType,
@@ -216,7 +243,7 @@ end architecture;
 				IsLast:    i == len(ports)-1,
 			}
 			mData.Ports = append(mData.Ports, pData)
-			
+
 			if port.Direction == "INPUT" || port.Direction == "INOUT" {
 				mData.InputPorts = append(mData.InputPorts, pData)
 			}
@@ -229,9 +256,14 @@ end architecture;
 		data.Modules = append(data.Modules, mData)
 	}
 
-	tmpl := template.Must(template.New("vhdl").Parse(vhdlTemplate))
-	if err := tmpl.Execute(out, data); err != nil {
-		log.Fatalf("Error executing VHDL template: %v", err)
+	entityTmpl := template.Must(template.New("vhdlEntity").Parse(vhdlEntityTemplate))
+	if err := entityTmpl.Execute(entityOut, data); err != nil {
+		log.Fatalf("Error executing VHDL entity template: %v", err)
+	}
+
+	archTmpl := template.Must(template.New("vhdlArch").Parse(vhdlArchTemplate))
+	if err := archTmpl.Execute(archOut, data); err != nil {
+		log.Fatalf("Error executing VHDL architecture template: %v", err)
 	}
 }
 

--- a/internal/cosim/generate_bridge_test.go
+++ b/internal/cosim/generate_bridge_test.go
@@ -62,7 +62,7 @@ func TestGenerateVHDL(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var buf bytes.Buffer
-			generateVHDL(tt.modules, nil, &buf, tt.modules[0].Name)
+			generateVHDL(tt.modules, nil, &buf, &buf, tt.modules[0].Name)
 			output := buf.String()
 
 			for _, part := range tt.expectedParts {


### PR DESCRIPTION
This PR adds the `separate_entity_arch` parameter to the `nvc_verilator_cosim` macro.

When enabled, it outputs separate VHDL files for the entity and architecture. It also exposes a `.archonly` target that aliases to the architecture file, allowing users to define their own custom VHDL entity and combine it with the generated architecture.

Added two integration tests:
- `cosim_separate`: Verifies the separate generation and linkage.
- `cosim_manual_entity`: Demonstrates using `.archonly` with a manually written VHDL entity.

All new and modified files have been updated with the required SPDX license headers.