### PR TITLE
Ai dev 20260511 fn vx qv apt deps

### DIFF
--- a/build/nvc/nvc_wrapper.sh
+++ b/build/nvc/nvc_wrapper.sh
@@ -157,9 +157,24 @@ _nvc_bin_dir=$(dirname "${gotopt2_nvc_binary_path}")
 # Assuming the path is .../usr/bin, the lib dir is .../usr/lib/x86_64-linux-gnu
 _nvc_ld_lib_path="${_nvc_bin_dir}/../lib/x86_64-linux-gnu"
 
-export LD_LIBRARY_PATH="${_nvc_ld_lib_path}:${LD_LIBRARY_PATH}"
+export LD_LIBRARY_PATH="${_nvc_ld_lib_path}:${NVC_LD_LIBRARY_PATH:-$LD_LIBRARY_PATH}"
 
-eval "${gotopt2_nvc_binary_path}" \
+_ld_so=""
+# When running with a specific Ubuntu version's dependencies (like 24.04), we may
+# have a different glibc (libc.so.6) in our NVC_LD_LIBRARY_PATH than the host system.
+# Executing the binary directly can cause a crash if the host's dynamic linker (ld.so)
+# tries to load the newer/incompatible libc.so.6 provided by the apt dependencies.
+# To prevent this, we look for the dynamic linker within the apt dependencies and
+# execute the nvc binary through it.
+IFS=':' read -ra LD_DIRS <<< "${NVC_LD_LIBRARY_PATH:-}"
+for _dir in "${LD_DIRS[@]}"; do
+  if [[ -x "$_dir/ld-linux-x86-64.so.2" ]]; then
+    _ld_so="$_dir/ld-linux-x86-64.so.2"
+    break
+  fi
+done
+
+eval ${_ld_so:+"$_ld_so"} "${gotopt2_nvc_binary_path}" \
   --std="${gotopt2_vhdl_standard}" \
   -L "${gotopt2_stdlib_dir}/nvc" \
   ${gotopt2_library_paths} \

--- a/internal/vhdl_elaborate.bzl
+++ b/internal/vhdl_elaborate.bzl
@@ -65,7 +65,7 @@ def _vhdl_elaborate(ctx):
         inputs = depset(direct = [vhdl_provider.library_dir] + ([std_lib_dir] if hasattr(std_lib_dir, "path") else []) + artifacts + nvc_deps + deps_paths + vpi_plugins).to_list(),
         executable = ctx.executable._script.path,
         env = {
-            "LD_LIBRARY_PATH": get_nvc_ld_library_path(nvc_info, base_dir, ctx.configuration.default_shell_env),
+            "NVC_LD_LIBRARY_PATH": get_nvc_ld_library_path(nvc_info, base_dir, ctx.configuration.default_shell_env),
         },
         arguments = [
             "--vhdl-standard={}".format(ctx.attr.standard),

--- a/internal/vhdl_library.bzl
+++ b/internal/vhdl_library.bzl
@@ -23,7 +23,7 @@ def _vhdl_library(ctx):
         if artifact.path.endswith("usr/lib/x86_64-linux-gnu/nvc"):
             std_lib_dir = artifact
             break
-            
+
     if not std_lib_dir:
         # Fallback if specific directory match fails, try to find a known file
         for artifact in artifacts:
@@ -32,7 +32,7 @@ def _vhdl_library(ctx):
                  # dirname of std/STD.STANDARD is std, we need the parent 'nvc'
                  # We'll just construct the path directly below
                  break
-                 
+
     # Construct the path to the nvc library directory based on the analyzer path
     # Analyzer is at external/nvc_deb/usr/bin/nvc
     # Library is at external/nvc_deb/usr/lib/x86_64-linux-gnu/nvc
@@ -62,7 +62,7 @@ def _vhdl_library(ctx):
         for name, path in vhdl_provider.libraries:
             flag_libraries += ["-L", "{path}".format(path=path.path)]
             seen += [name]
-    
+
     # Add VPI plugins from this target
     vpi_plugins.append(depset(ctx.files.vpi_plugins))
 
@@ -72,7 +72,7 @@ def _vhdl_library(ctx):
         inputs = srcs + deps_files + nvc_deps,
         executable =  analyzer, # how do I get its path?
         env = {
-            "LD_LIBRARY_PATH": get_nvc_ld_library_path(nvc_info, base_dir, ctx.configuration.default_shell_env),
+            "NVC_LD_LIBRARY_PATH": get_nvc_ld_library_path(nvc_info, base_dir, ctx.configuration.default_shell_env),
         },
         arguments = [
           "--std={}".format(ctx.attr.standard),

--- a/internal/vhdl_run.bzl
+++ b/internal/vhdl_run.bzl
@@ -75,7 +75,7 @@ def _vhdl_run(ctx):
         inputs = depset(direct = deps_paths + [vhdl_provider.library_dir] + ([std_lib_dir] if hasattr(std_lib_dir, "path") else []) + artifacts + nvc_deps + vpi_plugins).to_list(),
         executable = ctx.executable._script.path,
         env = {
-            "LD_LIBRARY_PATH": get_nvc_ld_library_path(nvc_info, base_dir, ctx.configuration.default_shell_env),
+            "NVC_LD_LIBRARY_PATH": get_nvc_ld_library_path(nvc_info, base_dir, ctx.configuration.default_shell_env),
         },
         arguments = [
             "-cmd=-r",


### PR DESCRIPTION
Configure apt.ubuntu in MODULE.bazel to provide libelf1, libzstd1, and zlib1g for Ubuntu 22.04 and 24.04.
Patch bazel_linux_packages to use rules_shell for sh_binary.
Populate lockfiles using bazel run @deps_XX_04//:lock.

This commit has been created by an automated coding assistant,
with human supervision.
Prompt: the libraries needed by nvc need to be provided by `apt.ubuntu(...)` use `bazel run @deps_22_04//:lock` to populate the lockfile, similarly for the 24_04 variant... create PR when done