### PR TITLE
ci: update github workflows to run on ubuntu-latest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Setup bazel
         uses: bazel-contrib/setup-bazel@0.15.0

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   tag:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     outputs:
       tag_name: ${{ steps.tag_version.outputs.new_tag }}
     steps:


### PR DESCRIPTION
Modify the build and tag-and-release GitHub workflows to use ubuntu-latest instead of ubuntu-22.04 for their runner environments.

This pull request has been created by an automated coding assistant, with human supervision.
Prompt: new feature in new branch, send pr: modify the github workflows to "run-under" ubuntu-latest instead of ubuntu-22.04