### PR TITLE
feat: modify vhdl_run to run on bazel test

### DIFF
--- a/build/nvc/rules.md
+++ b/build/nvc/rules.md
@@ -181,23 +181,17 @@ Compiles VHDL source files into a library using NVC.
 <pre>
 load("@rules_nvc//build/nvc:rules.bzl", "vhdl_run")
 
-vhdl_run(<a href="#vhdl_run-name">name</a>, <a href="#vhdl_run-deps">deps</a>, <a href="#vhdl_run-args">args</a>, <a href="#vhdl_run-entity">entity</a>, <a href="#vhdl_run-standard">standard</a>, <a href="#vhdl_run-use_fst">use_fst</a>, <a href="#vhdl_run-use_vcd">use_vcd</a>)
+vhdl_run(<a href="#vhdl_run-kwargs">**kwargs</a>)
 </pre>
 
-Simulates an elaborated VHDL design using NVC.
-
-**ATTRIBUTES**
 
 
-| Name  | Description | Type | Mandatory | Default |
-| :------------- | :------------- | :------------- | :------------- | :------------- |
-| <a id="vhdl_run-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
-| <a id="vhdl_run-deps"></a>deps |  A list of other `vhdl_library` targets that this simulation depends on.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
-| <a id="vhdl_run-args"></a>args |  A list of added command line args to use   | List of strings | optional |  `[]`  |
-| <a id="vhdl_run-entity"></a>entity |  The elaborated VHDL entity to simulate. This should be a `vhdl_elaborate` target.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
-| <a id="vhdl_run-standard"></a>standard |  The VHDL standard to use for simulation. Defaults to '2019'.   | String | optional |  `"2019"`  |
-| <a id="vhdl_run-use_fst"></a>use_fst |  A boolean indicating whether to generate a FST file for waveform viewing. Defaults to `False`. Takes precedence over `use_vcd`.   | Boolean | optional |  `False`  |
-| <a id="vhdl_run-use_vcd"></a>use_vcd |  A boolean indicating whether to generate a VCD (Value Change Dump) file for waveform viewing. Defaults to `True`.   | Boolean | optional |  `True`  |
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="vhdl_run-kwargs"></a>kwargs |  <p align="center"> - </p>   |  none |
 
 
 <a id="vhdl_test"></a>
@@ -262,7 +256,7 @@ Generates a sh_binary viewer.
 | <a id="wave_view-args"></a>args |  <p align="center"> - </p>   |  `[]` |
 | <a id="wave_view-deps"></a>deps |  <p align="center"> - </p>   |  `[]` |
 | <a id="wave_view-viewer"></a>viewer |  <p align="center"> - </p>   |  `"gtkwave"` |
-| <a id="wave_view-testonly"></a>testonly |  <p align="center"> - </p>   |  `None` |
+| <a id="wave_view-testonly"></a>testonly |  <p align="center"> - </p>   |  `True` |
 | <a id="wave_view-save_file"></a>save_file |  <p align="center"> - </p>   |  `None` |
 
 

--- a/internal/macros.bzl
+++ b/internal/macros.bzl
@@ -1,7 +1,7 @@
 load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
 
 
-def wave_view(name, vhdl_run, args=[], deps=[], viewer="gtkwave", testonly=None, save_file=None):
+def wave_view(name, vhdl_run, args=[], deps=[], viewer="gtkwave", testonly=True, save_file=None):
     """
     Generates a sh_binary viewer.
 

--- a/internal/macros.md
+++ b/internal/macros.md
@@ -34,7 +34,7 @@ Generates a sh_binary viewer.
 | <a id="wave_view-args"></a>args |  <p align="center"> - </p>   |  `[]` |
 | <a id="wave_view-deps"></a>deps |  <p align="center"> - </p>   |  `[]` |
 | <a id="wave_view-viewer"></a>viewer |  <p align="center"> - </p>   |  `"gtkwave"` |
-| <a id="wave_view-testonly"></a>testonly |  <p align="center"> - </p>   |  `None` |
+| <a id="wave_view-testonly"></a>testonly |  <p align="center"> - </p>   |  `True` |
 | <a id="wave_view-save_file"></a>save_file |  <p align="center"> - </p>   |  `None` |
 
 

--- a/internal/vhdl_run.bzl
+++ b/internal/vhdl_run.bzl
@@ -11,7 +11,7 @@ def _vhdl_run(ctx):
     nvc_info = ctx.toolchains[_NVC_TOOLCHAIN_TYPE].nvc_info
     nvc_deps = get_nvc_deps(nvc_info)
     analyzer_x = nvc_info.analyzer.files.to_list()[0]
-    analyzer = analyzer_x.path
+    analyzer = analyzer_x.short_path
     library_name = ctx.attr.name
 
     artifacts = nvc_info.artifacts_dir.files.to_list()
@@ -42,7 +42,7 @@ def _vhdl_run(ctx):
     for name, path in vhdl_provider.libraries:
         if name != vhdl_provider.library_name and name not in seen:
             flag_libraries += [
-                "--map={}:{}/{}".format(name, path.path, name)]
+                "--map={}:{}/{}".format(name, path.short_path, name)]
             deps_paths += [path]
             seen += [name]
 
@@ -53,61 +53,81 @@ def _vhdl_run(ctx):
     if ctx.attr.use_fst:
         ext = "fst"
 
-    wave_file = ctx.actions.declare_file(
-        "{}.{}".format(ctx.attr.name, ext))
-
-    format = []
+    format_args = []
     if ctx.attr.use_fst:
-        format = [ "--format=fst" ]
+        format_args = [ "--format=fst" ]
     elif ctx.attr.use_vcd:
-        format = [ "--format=vcd" ]
+        format_args = [ "--format=vcd" ]
 
     elaborate_provider = ctx.attr.entity[ElaborateProvider]
 
+    runfiles = ctx.runfiles(
+        files=[vhdl_provider.library_dir] + ctx.attr._script.files.to_list(),
+        transitive_files=depset(artifacts + deps_paths))
+
+    # Collect VPI plugins
     vpi_plugins = vhdl_provider.vpi_plugins.to_list()
-    vpi_flags = []
-    for p in vpi_plugins:
-        vpi_flags += ["-m", p.path]
+    runfiles = runfiles.merge(ctx.runfiles(files = vpi_plugins))
 
-    runfiles = ctx.runfiles(files = [wave_file] + vpi_plugins)
-    ctx.actions.run(
-        outputs = [wave_file],
-        inputs = depset(direct = deps_paths + [vhdl_provider.library_dir] + ([std_lib_dir] if hasattr(std_lib_dir, "path") else []) + artifacts + nvc_deps + vpi_plugins).to_list(),
-        executable = ctx.executable._script.path,
-        env = {
-            "NVC_LD_LIBRARY_PATH": get_nvc_ld_library_path(nvc_info, base_dir, ctx.configuration.default_shell_env),
+    # Construct --load= flags for VPI plugins
+    vpi_flags = ""
+    if vpi_plugins:
+        vpi_flags = "--load={}".format(",".join([p.short_path for p in vpi_plugins]))
+    
+    # Add user arguments
+    extra_args = " ".join(ctx.attr.args + format_args)
+
+    runfiles = runfiles.merge_all([ctx.attr._script[DefaultInfo].default_runfiles])
+    inputs = deps_paths + [vhdl_provider.library_dir] + ([std_lib_dir] if hasattr(std_lib_dir, "path") else []) + artifacts + vpi_plugins + nvc_deps
+    i_runfiles = ctx.runfiles(files = inputs)
+
+    tools = [analyzer_x, ctx.executable._script, ] + artifacts
+    t_runfiles = ctx.runfiles(files = tools)
+
+    runfiles.merge_all([t_runfiles, i_runfiles, ctx.attr._script[DefaultInfo].default_runfiles])
+    
+    # Calculate the runfiles prefix path
+    # If the workspace is not _main (e.g. we are an external repo), we need to prefix the paths
+    nvc_lib_path_for_wrapper = nvc_lib_path
+    if nvc_lib_path.startswith("external/"):
+        nvc_lib_path_for_wrapper = "../" + nvc_lib_path[9:]
+
+    analyzer_for_wrapper = analyzer
+    if analyzer.startswith("external/"):
+        analyzer_for_wrapper = "../" + analyzer[9:]
+
+    base_dir_for_wrapper = base_dir
+    if base_dir.startswith("external/"):
+        base_dir_for_wrapper = "../" + base_dir[9:]
+
+    nvc_ld_library_path = get_nvc_ld_library_path(nvc_info, base_dir, ctx.configuration.default_shell_env)
+    
+    # Prefix external paths for NVC_LD_LIBRARY_PATH if needed
+    # (Just passing the literal value for now, we can adapt the NVC wrapper or base_dir if needed)
+    
+    ctx.actions.expand_template(
+        template = ctx.file._template,
+        output = ctx.outputs.executable,
+        substitutions = {
+            "{{EXECUTABLE}}": "NVC_LD_LIBRARY_PATH=\"" + nvc_ld_library_path + "\" LD_LIBRARY_PATH=\"" + base_dir_for_wrapper + "/lib/x86_64-linux-gnu\" " + ctx.executable._script.short_path,
+            "{{VHDL_STANDARD}}": ctx.attr.standard,
+            "{{ANALYZER}}": analyzer_for_wrapper,
+            "{{LIBRARY_NAME}}": vhdl_provider.library_name,
+            "{{LIBRARY_PATHS}}": " ".join(flag_libraries + ["-L", nvc_lib_path_for_wrapper]),
+            "{{STDLIB_DIR}}": nvc_lib_path_for_wrapper[:-4],
+            "{{ENTITY}}": elaborate_provider.entity,
+            "{{LIB_DIR_IN_PATH}}": vhdl_provider.library_dir.short_path,
+            "{{LIB_DIR_OUT_PATH}}": work_library_file.short_path,
+            "{{WAVE_FILE}}": "{}.{}".format(ctx.attr.name, ext),
+            "{{VPI_FLAGS}}": vpi_flags,
+            "{{EXTRA_ARGS}}": extra_args,
         },
-        arguments = [
-            "-cmd=-r",
-            "--vhdl-standard={}".format(ctx.attr.standard),
-            "--nvc-binary-path={}".format(analyzer),
-            "--library-name={}".format(vhdl_provider.library_name),
-            "--library-paths={}".format(" ".join(flag_libraries + ["-L", nvc_lib_path])),
-            "--stdlib-dir={}".format(nvc_lib_path[:-4]),
-            "--entity={}".format(elaborate_provider.entity),
-            "--library-dir-in-path={}".format(work_library_file.path),
-            "--library-dir-out-path={}".format(work_library_file.path),
-            "--",
-        ] + vpi_flags + ctx.attr.args + [
-            "--wave={}".format(wave_file.path),
-        ] + format,
-        tools = [analyzer_x, ctx.executable._script] + artifacts,
-        # Only seems to work from bazel 6.0.0 on.
-        #toolchain = _NVC_TOOLCHAIN_TYPE,
-        progress_message = "Simulating VHDL: {}.{} at {}".format(
-            vhdl_provider.library_name,
-            elaborate_provider.entity,
-            work_library_file.path),
     )
-    return [
-        DefaultInfo(
-            files=depset([wave_file]),
-            runfiles=runfiles,
-        ),
-    ]
+    return [DefaultInfo(runfiles=runfiles)]
 
-vhdl_run = rule(
+_vhdl_run_test = rule(
     doc = "Simulates an elaborated VHDL design using NVC.",
+    test = True,
     implementation = _vhdl_run,
     attrs = {
         "entity": attr.label(
@@ -135,11 +155,17 @@ vhdl_run = rule(
             default = False,
             doc = "A boolean indicating whether to generate a FST file for waveform viewing. Defaults to `False`. Takes precedence over `use_vcd`.",
         ),
-        "args": attr.string_list(
-            doc = "A list of added command line args to use",
+        "_template": attr.label(
+            default = Label("//build/nvc:unittest.tpl.sh"),
+            allow_single_file = True,
+            doc = "Template for the test execution script.",
         ),
     },
     toolchains = [
       _NVC_TOOLCHAIN_TYPE,
     ],
 )
+
+
+def vhdl_run(**kwargs):
+    _vhdl_run_test(**kwargs)

--- a/internal/vhdl_run.md
+++ b/internal/vhdl_run.md
@@ -9,22 +9,16 @@
 <pre>
 load("@rules_nvc//internal:vhdl_run.bzl", "vhdl_run")
 
-vhdl_run(<a href="#vhdl_run-name">name</a>, <a href="#vhdl_run-deps">deps</a>, <a href="#vhdl_run-args">args</a>, <a href="#vhdl_run-entity">entity</a>, <a href="#vhdl_run-standard">standard</a>, <a href="#vhdl_run-use_fst">use_fst</a>, <a href="#vhdl_run-use_vcd">use_vcd</a>)
+vhdl_run(<a href="#vhdl_run-kwargs">**kwargs</a>)
 </pre>
 
-Simulates an elaborated VHDL design using NVC.
-
-**ATTRIBUTES**
 
 
-| Name  | Description | Type | Mandatory | Default |
-| :------------- | :------------- | :------------- | :------------- | :------------- |
-| <a id="vhdl_run-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
-| <a id="vhdl_run-deps"></a>deps |  A list of other `vhdl_library` targets that this simulation depends on.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
-| <a id="vhdl_run-args"></a>args |  A list of added command line args to use   | List of strings | optional |  `[]`  |
-| <a id="vhdl_run-entity"></a>entity |  The elaborated VHDL entity to simulate. This should be a `vhdl_elaborate` target.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
-| <a id="vhdl_run-standard"></a>standard |  The VHDL standard to use for simulation. Defaults to '2019'.   | String | optional |  `"2019"`  |
-| <a id="vhdl_run-use_fst"></a>use_fst |  A boolean indicating whether to generate a FST file for waveform viewing. Defaults to `False`. Takes precedence over `use_vcd`.   | Boolean | optional |  `False`  |
-| <a id="vhdl_run-use_vcd"></a>use_vcd |  A boolean indicating whether to generate a VCD (Value Change Dump) file for waveform viewing. Defaults to `True`.   | Boolean | optional |  `True`  |
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="vhdl_run-kwargs"></a>kwargs |  <p align="center"> - </p>   |  none |
 
 

--- a/nvc/rules.md
+++ b/nvc/rules.md
@@ -126,23 +126,17 @@ Compiles VHDL source files into a library using NVC.
 <pre>
 load("@rules_nvc//nvc:rules.bzl", "vhdl_run")
 
-vhdl_run(<a href="#vhdl_run-name">name</a>, <a href="#vhdl_run-deps">deps</a>, <a href="#vhdl_run-args">args</a>, <a href="#vhdl_run-entity">entity</a>, <a href="#vhdl_run-standard">standard</a>, <a href="#vhdl_run-use_fst">use_fst</a>, <a href="#vhdl_run-use_vcd">use_vcd</a>)
+vhdl_run(<a href="#vhdl_run-kwargs">**kwargs</a>)
 </pre>
 
-Simulates an elaborated VHDL design using NVC.
-
-**ATTRIBUTES**
 
 
-| Name  | Description | Type | Mandatory | Default |
-| :------------- | :------------- | :------------- | :------------- | :------------- |
-| <a id="vhdl_run-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
-| <a id="vhdl_run-deps"></a>deps |  A list of other `vhdl_library` targets that this simulation depends on.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
-| <a id="vhdl_run-args"></a>args |  A list of added command line args to use   | List of strings | optional |  `[]`  |
-| <a id="vhdl_run-entity"></a>entity |  The elaborated VHDL entity to simulate. This should be a `vhdl_elaborate` target.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
-| <a id="vhdl_run-standard"></a>standard |  The VHDL standard to use for simulation. Defaults to '2019'.   | String | optional |  `"2019"`  |
-| <a id="vhdl_run-use_fst"></a>use_fst |  A boolean indicating whether to generate a FST file for waveform viewing. Defaults to `False`. Takes precedence over `use_vcd`.   | Boolean | optional |  `False`  |
-| <a id="vhdl_run-use_vcd"></a>use_vcd |  A boolean indicating whether to generate a VCD (Value Change Dump) file for waveform viewing. Defaults to `True`.   | Boolean | optional |  `True`  |
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="vhdl_run-kwargs"></a>kwargs |  <p align="center"> - </p>   |  none |
 
 
 <a id="vhdl_test"></a>
@@ -207,7 +201,7 @@ Generates a sh_binary viewer.
 | <a id="wave_view-args"></a>args |  <p align="center"> - </p>   |  `[]` |
 | <a id="wave_view-deps"></a>deps |  <p align="center"> - </p>   |  `[]` |
 | <a id="wave_view-viewer"></a>viewer |  <p align="center"> - </p>   |  `"gtkwave"` |
-| <a id="wave_view-testonly"></a>testonly |  <p align="center"> - </p>   |  `None` |
+| <a id="wave_view-testonly"></a>testonly |  <p align="center"> - </p>   |  `True` |
 | <a id="wave_view-save_file"></a>save_file |  <p align="center"> - </p>   |  `None` |
 
 


### PR DESCRIPTION
Rewrite vhdl_run in vhdl_run.bzl to be a test rule instead of an executable rule.
This makes vhdl_run similar to vhdl_test by using a bash template to execute the simulation during the `bazel test` phase instead of the `bazel build` phase.
Also updates `wave_view` macro in macros.bzl to propagate `testonly=True` implicitly.

This pull request has been created by an automated coding assistant, with human supervision.
Prompt: new feature, new branch, new pr: modify vhdl_run rule (vhdl_run.bzl) such that it runs on bazel test, not bazel build. In that respect it should be somewhat similar to vhdl_test rule