### PR TITLE
fix: set default ubuntu_version to 24.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Setup bazel
         uses: bazel-contrib/setup-bazel@0.15.0

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   tag:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     outputs:
       tag_name: ${{ steps.tag_version.outputs.new_tag }}
     steps:

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -36,8 +36,13 @@ apt.ubuntu(
     lockfile = "//:deps_22_04.lock.json",
     packages = [
         "libelf1",
+        "libdw1",
+        "libffi8",
+        "libllvm14",
         "libzstd1",
         "zlib1g",
+        "libtcl8.6",
+        "libreadline8",
     ],
     suites = ["jammy"],
 )
@@ -49,8 +54,13 @@ apt.ubuntu(
     lockfile = "//:deps_24_04.lock.json",
     packages = [
         "libelf1t64",
+        "libdw1t64",
+        "libffi8",
+        "libllvm18",
         "libzstd1",
         "zlib1g",
+        "libtcl8.6",
+        "libreadline8t64",
     ],
     suites = ["noble"],
 )
@@ -67,7 +77,13 @@ register_toolchains("//build/nvc:nvc_linux_toolchain")
 deb_extract = use_repo_rule("//internal:deb_extract.bzl", "deb_extract")
 
 deb_extract(
-    name = "nvc_deb",
+    name = "nvc_deb_22_04",
     integrity = "sha256-+lrK9P7xSifskXHCgs0BuHBatiRWs4jYyefxOj6qaVA=",
     urls = ["https://github.com/nickg/nvc/releases/download/r1.20.1/nvc_1.20.1-1_amd64_ubuntu-22.04.deb"],
+)
+
+deb_extract(
+    name = "nvc_deb_24_04",
+    integrity = "sha256-rh08AlQ9rITN3nlITX4BisvMjZtvBoAnk7QU0aJwwxo=",
+    urls = ["https://github.com/nickg/nvc/releases/download/r1.20.1/nvc_1.20.1-1_amd64_ubuntu-24.04.deb"],
 )

--- a/build/nvc/BUILD.bazel
+++ b/build/nvc/BUILD.bazel
@@ -29,6 +29,12 @@ toolchain(
 )
 
 sh_binary(
+    name = "nvc_direct_wrapper",
+    srcs = ["nvc_direct_wrapper.sh"],
+    visibility = ["//visibility:public"],
+)
+
+sh_binary(
     name = "nvc_wrapper",
     srcs = ["nvc_wrapper.sh"],
     data = [

--- a/build/nvc/nvc_direct_wrapper.sh
+++ b/build/nvc/nvc_direct_wrapper.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+_ld_so=""
+IFS=':' read -ra LD_DIRS <<< "${NVC_LD_LIBRARY_PATH:-}"
+for _dir in "${LD_DIRS[@]}"; do
+  if [[ -x "$_dir/ld-linux-x86-64.so.2" ]]; then
+    _ld_so="$_dir/ld-linux-x86-64.so.2"
+    break
+  fi
+done
+export LD_LIBRARY_PATH="${NVC_LD_LIBRARY_PATH:-$LD_LIBRARY_PATH}"
+exec ${_ld_so:+"$_ld_so"} "$@"

--- a/build/nvc/nvc_wrapper.sh
+++ b/build/nvc/nvc_wrapper.sh
@@ -174,6 +174,10 @@ for _dir in "${LD_DIRS[@]}"; do
   fi
 done
 
+echo "LD_SO is $_ld_so" >&2
+echo "NVC_LD_LIBRARY_PATH is $NVC_LD_LIBRARY_PATH" >&2
+echo "LD_LIBRARY_PATH is $LD_LIBRARY_PATH" >&2
+
 eval ${_ld_so:+"$_ld_so"} "${gotopt2_nvc_binary_path}" \
   --std="${gotopt2_vhdl_standard}" \
   -L "${gotopt2_stdlib_dir}/nvc" \

--- a/deps_22_04.lock.json
+++ b/deps_22_04.lock.json
@@ -4,7 +4,12 @@
 			"amd64"
 		],
 		"packages": [
+			"libdw1",
 			"libelf1",
+			"libffi8",
+			"libllvm14",
+			"libreadline8",
+			"libtcl8.6",
 			"libzstd1",
 			"zlib1g"
 		],
@@ -27,11 +32,56 @@
 		{
 			"arch": "amd64",
 			"dependencies": [],
+			"key": "debconf_1.5.79ubuntu1_amd64",
+			"name": "debconf",
+			"sha256": "395a65b3a9539304391456d4d0e5531f4249f297b6e67eb0fcaf2ff77ddc3dc3",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20250219T154000Z/pool/main/d/debconf/debconf_1.5.79ubuntu1_all.deb",
+			"version": "1.5.79ubuntu1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "dpkg_1.21.1ubuntu2_amd64",
+			"name": "dpkg",
+			"sha256": "457a683c3209ac30338461b0f3f7641879a4ce15adff15fbcbc20f3430d0c84b",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20250219T154000Z/pool/main/d/dpkg/dpkg_1.21.1ubuntu2_amd64.deb",
+			"version": "1.21.1ubuntu2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
 			"key": "gcc-12-base_12-20220319-1ubuntu1_amd64",
 			"name": "gcc-12-base",
 			"sha256": "37990a768ecb1b40ce87c12fb7c7994877bb1256bde286c8e9bf5d4b51a17ca9",
 			"url": "https://snapshot.ubuntu.com/ubuntu/20250219T154000Z/pool/main/g/gcc-12/gcc-12-base_12-20220319-1ubuntu1_amd64.deb",
 			"version": "12-20220319-1ubuntu1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libacl1_2.3.1-1_amd64",
+			"name": "libacl1",
+			"sha256": "4db2c64ec74f673ed022e92cce7b83d0cbe0b779e02ca60a56ba59ae07754e05",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20250219T154000Z/pool/main/a/acl/libacl1_2.3.1-1_amd64.deb",
+			"version": "2.3.1-1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libbsd0_0.11.5-1_amd64",
+			"name": "libbsd0",
+			"sha256": "09367acdf59f28ffb71ba7bc36c516cff03b2765930cf9be7bb7ea7273e4c312",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20250219T154000Z/pool/main/libb/libbsd/libbsd0_0.11.5-1_amd64.deb",
+			"version": "0.11.5-1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libbz2-1.0_1.0.8-5build1_amd64",
+			"name": "libbz2-1.0",
+			"sha256": "3bfeaf4259eadbb7faa09feee86cd6cad172cd95907d7465afd0eb5aebb5433f",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20250219T154000Z/pool/main/b/bzip2/libbz2-1.0_1.0.8-5build1_amd64.deb",
+			"version": "1.0.8-5build1"
 		},
 		{
 			"arch": "amd64",
@@ -50,6 +100,65 @@
 			"sha256": "3fa566e9f861a08736cbc5a97562d9d6e4f0c00450fbeafcb6d7583423b04a98",
 			"url": "https://snapshot.ubuntu.com/ubuntu/20250219T154000Z/pool/main/libx/libxcrypt/libcrypt1_4.4.27-1_amd64.deb",
 			"version": "1:4.4.27-1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [
+				{
+					"key": "gcc-12-base_12-20220319-1ubuntu1_amd64",
+					"name": "gcc-12-base",
+					"version": "12-20220319-1ubuntu1"
+				},
+				{
+					"key": "libbz2-1.0_1.0.8-5build1_amd64",
+					"name": "libbz2-1.0",
+					"version": "1.0.8-5build1"
+				},
+				{
+					"key": "libc6_2.35-0ubuntu3_amd64",
+					"name": "libc6",
+					"version": "2.35-0ubuntu3"
+				},
+				{
+					"key": "libcrypt1_1-4.4.27-1_amd64",
+					"name": "libcrypt1",
+					"version": "1:4.4.27-1"
+				},
+				{
+					"key": "libelf1_0.186-1build1_amd64",
+					"name": "libelf1",
+					"version": "0.186-1build1"
+				},
+				{
+					"key": "libgcc-s1_12-20220319-1ubuntu1_amd64",
+					"name": "libgcc-s1",
+					"version": "12-20220319-1ubuntu1"
+				},
+				{
+					"key": "liblzma5_5.2.5-2ubuntu1_amd64",
+					"name": "liblzma5",
+					"version": "5.2.5-2ubuntu1"
+				},
+				{
+					"key": "zlib1g_1-1.2.11.dfsg-2ubuntu9_amd64",
+					"name": "zlib1g",
+					"version": "1:1.2.11.dfsg-2ubuntu9"
+				}
+			],
+			"key": "libdw1_0.186-1build1_amd64",
+			"name": "libdw1",
+			"sha256": "ec6eff38e81bcaa462b09e18c2a7972e7b2e1cac24268424a6cf87b010a10704",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20250219T154000Z/pool/main/e/elfutils/libdw1_0.186-1build1_amd64.deb",
+			"version": "0.186-1build1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libedit2_3.1-20210910-1build1_amd64",
+			"name": "libedit2",
+			"sha256": "fb8783bdf0a59aaabf4e9b29192170f6cc17aa2eb94bc672c15add37ff39525b",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20250219T154000Z/pool/main/libe/libedit/libedit2_3.1-20210910-1build1_amd64.deb",
+			"version": "3.1-20210910-1build1"
 		},
 		{
 			"arch": "amd64",
@@ -88,12 +197,369 @@
 		},
 		{
 			"arch": "amd64",
+			"dependencies": [
+				{
+					"key": "gcc-12-base_12-20220319-1ubuntu1_amd64",
+					"name": "gcc-12-base",
+					"version": "12-20220319-1ubuntu1"
+				},
+				{
+					"key": "libc6_2.35-0ubuntu3_amd64",
+					"name": "libc6",
+					"version": "2.35-0ubuntu3"
+				},
+				{
+					"key": "libcrypt1_1-4.4.27-1_amd64",
+					"name": "libcrypt1",
+					"version": "1:4.4.27-1"
+				},
+				{
+					"key": "libgcc-s1_12-20220319-1ubuntu1_amd64",
+					"name": "libgcc-s1",
+					"version": "12-20220319-1ubuntu1"
+				}
+			],
+			"key": "libffi8_3.4.2-4_amd64",
+			"name": "libffi8",
+			"sha256": "b4f88c91fa6f4c942097be6abfc365fb133c5e147640168cbb7704fd855eac10",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20250219T154000Z/pool/main/libf/libffi/libffi8_3.4.2-4_amd64.deb",
+			"version": "3.4.2-4"
+		},
+		{
+			"arch": "amd64",
 			"dependencies": [],
 			"key": "libgcc-s1_12-20220319-1ubuntu1_amd64",
 			"name": "libgcc-s1",
 			"sha256": "c9a93721431be07557c810d7e1b24c3b3c51f398334ded104362a68a415b9e61",
 			"url": "https://snapshot.ubuntu.com/ubuntu/20250219T154000Z/pool/main/g/gcc-12/libgcc-s1_12-20220319-1ubuntu1_amd64.deb",
 			"version": "12-20220319-1ubuntu1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libicu70_70.1-2_amd64",
+			"name": "libicu70",
+			"sha256": "58a154f6307289813da2276f900498ef536ae7c0522d2cf31a3c3c5cf62dfd9a",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20250219T154000Z/pool/main/i/icu/libicu70_70.1-2_amd64.deb",
+			"version": "70.1-2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [
+				{
+					"key": "gcc-12-base_12-20220319-1ubuntu1_amd64",
+					"name": "gcc-12-base",
+					"version": "12-20220319-1ubuntu1"
+				},
+				{
+					"key": "libbsd0_0.11.5-1_amd64",
+					"name": "libbsd0",
+					"version": "0.11.5-1"
+				},
+				{
+					"key": "libc6_2.35-0ubuntu3_amd64",
+					"name": "libc6",
+					"version": "2.35-0ubuntu3"
+				},
+				{
+					"key": "libcrypt1_1-4.4.27-1_amd64",
+					"name": "libcrypt1",
+					"version": "1:4.4.27-1"
+				},
+				{
+					"key": "libedit2_3.1-20210910-1build1_amd64",
+					"name": "libedit2",
+					"version": "3.1-20210910-1build1"
+				},
+				{
+					"key": "libffi8_3.4.2-4_amd64",
+					"name": "libffi8",
+					"version": "3.4.2-4"
+				},
+				{
+					"key": "libgcc-s1_12-20220319-1ubuntu1_amd64",
+					"name": "libgcc-s1",
+					"version": "12-20220319-1ubuntu1"
+				},
+				{
+					"key": "libicu70_70.1-2_amd64",
+					"name": "libicu70",
+					"version": "70.1-2"
+				},
+				{
+					"key": "liblzma5_5.2.5-2ubuntu1_amd64",
+					"name": "liblzma5",
+					"version": "5.2.5-2ubuntu1"
+				},
+				{
+					"key": "libmd0_1.0.4-1build1_amd64",
+					"name": "libmd0",
+					"version": "1.0.4-1build1"
+				},
+				{
+					"key": "libstdc-p--p-6_12-20220319-1ubuntu1_amd64",
+					"name": "libstdc++6",
+					"version": "12-20220319-1ubuntu1"
+				},
+				{
+					"key": "libtinfo6_6.3-2_amd64",
+					"name": "libtinfo6",
+					"version": "6.3-2"
+				},
+				{
+					"key": "libxml2_2.9.13-p-dfsg-1build1_amd64",
+					"name": "libxml2",
+					"version": "2.9.13+dfsg-1build1"
+				},
+				{
+					"key": "zlib1g_1-1.2.11.dfsg-2ubuntu9_amd64",
+					"name": "zlib1g",
+					"version": "1:1.2.11.dfsg-2ubuntu9"
+				}
+			],
+			"key": "libllvm14_1-14.0.0-1ubuntu1_amd64",
+			"name": "libllvm14",
+			"sha256": "f22411c833909b3e4fdfd2f182974302d70c114a799499def6f005c7a2d07854",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20250219T154000Z/pool/main/l/llvm-toolchain-14/libllvm14_14.0.0-1ubuntu1_amd64.deb",
+			"version": "1:14.0.0-1ubuntu1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "liblzma5_5.2.5-2ubuntu1_amd64",
+			"name": "liblzma5",
+			"sha256": "8f1c46e7d3f5102a5e4fdca7c949728a343ba71c2a7c124118df2c13d4c444f7",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20250219T154000Z/pool/main/x/xz-utils/liblzma5_5.2.5-2ubuntu1_amd64.deb",
+			"version": "5.2.5-2ubuntu1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libmd0_1.0.4-1build1_amd64",
+			"name": "libmd0",
+			"sha256": "bcdad5e400aeb660f0337a1c5c1a77e3effa91d0803e64ce2d000e9006f67cdb",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20250219T154000Z/pool/main/libm/libmd/libmd0_1.0.4-1build1_amd64.deb",
+			"version": "1.0.4-1build1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libpcre2-8-0_10.39-3build1_amd64",
+			"name": "libpcre2-8-0",
+			"sha256": "166e1162c3e86facf11bd31a3e10ffa67641f9ac295bc8e72e6cdfc494fc64c3",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20250219T154000Z/pool/main/p/pcre2/libpcre2-8-0_10.39-3build1_amd64.deb",
+			"version": "10.39-3build1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [
+				{
+					"key": "dpkg_1.21.1ubuntu2_amd64",
+					"name": "dpkg",
+					"version": "1.21.1ubuntu2"
+				},
+				{
+					"key": "gcc-12-base_12-20220319-1ubuntu1_amd64",
+					"name": "gcc-12-base",
+					"version": "12-20220319-1ubuntu1"
+				},
+				{
+					"key": "libacl1_2.3.1-1_amd64",
+					"name": "libacl1",
+					"version": "2.3.1-1"
+				},
+				{
+					"key": "libbz2-1.0_1.0.8-5build1_amd64",
+					"name": "libbz2-1.0",
+					"version": "1.0.8-5build1"
+				},
+				{
+					"key": "libc6_2.35-0ubuntu3_amd64",
+					"name": "libc6",
+					"version": "2.35-0ubuntu3"
+				},
+				{
+					"key": "libcrypt1_1-4.4.27-1_amd64",
+					"name": "libcrypt1",
+					"version": "1:4.4.27-1"
+				},
+				{
+					"key": "libgcc-s1_12-20220319-1ubuntu1_amd64",
+					"name": "libgcc-s1",
+					"version": "12-20220319-1ubuntu1"
+				},
+				{
+					"key": "liblzma5_5.2.5-2ubuntu1_amd64",
+					"name": "liblzma5",
+					"version": "5.2.5-2ubuntu1"
+				},
+				{
+					"key": "libpcre2-8-0_10.39-3build1_amd64",
+					"name": "libpcre2-8-0",
+					"version": "10.39-3build1"
+				},
+				{
+					"key": "libselinux1_3.3-1build2_amd64",
+					"name": "libselinux1",
+					"version": "3.3-1build2"
+				},
+				{
+					"key": "libtinfo6_6.3-2_amd64",
+					"name": "libtinfo6",
+					"version": "6.3-2"
+				},
+				{
+					"key": "libzstd1_1.4.8-p-dfsg-3build1_amd64",
+					"name": "libzstd1",
+					"version": "1.4.8+dfsg-3build1"
+				},
+				{
+					"key": "readline-common_8.1.2-1_amd64",
+					"name": "readline-common",
+					"version": "8.1.2-1"
+				},
+				{
+					"key": "tar_1.34-p-dfsg-1build3_amd64",
+					"name": "tar",
+					"version": "1.34+dfsg-1build3"
+				},
+				{
+					"key": "zlib1g_1-1.2.11.dfsg-2ubuntu9_amd64",
+					"name": "zlib1g",
+					"version": "1:1.2.11.dfsg-2ubuntu9"
+				}
+			],
+			"key": "libreadline8_8.1.2-1_amd64",
+			"name": "libreadline8",
+			"sha256": "51fd16f608efa710c987e4b071ffba0bec63a9ac8e55eddd5770f5e5252edc09",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20250219T154000Z/pool/main/r/readline/libreadline8_8.1.2-1_amd64.deb",
+			"version": "8.1.2-1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libselinux1_3.3-1build2_amd64",
+			"name": "libselinux1",
+			"sha256": "b96c6b40ee2388bd51341cb11c0f1d5bcca29b9180b6e3a77a06b881f2913f7e",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20250219T154000Z/pool/main/libs/libselinux/libselinux1_3.3-1build2_amd64.deb",
+			"version": "3.3-1build2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libstdc-p--p-6_12-20220319-1ubuntu1_amd64",
+			"name": "libstdc++6",
+			"sha256": "035cfe195ddf3a091abbc0c323285772ccbdbb2fb75279e44a0915748b4e5726",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20250219T154000Z/pool/main/g/gcc-12/libstdc++6_12-20220319-1ubuntu1_amd64.deb",
+			"version": "12-20220319-1ubuntu1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [
+				{
+					"key": "debconf_1.5.79ubuntu1_amd64",
+					"name": "debconf",
+					"version": "1.5.79ubuntu1"
+				},
+				{
+					"key": "dpkg_1.21.1ubuntu2_amd64",
+					"name": "dpkg",
+					"version": "1.21.1ubuntu2"
+				},
+				{
+					"key": "gcc-12-base_12-20220319-1ubuntu1_amd64",
+					"name": "gcc-12-base",
+					"version": "12-20220319-1ubuntu1"
+				},
+				{
+					"key": "libacl1_2.3.1-1_amd64",
+					"name": "libacl1",
+					"version": "2.3.1-1"
+				},
+				{
+					"key": "libbz2-1.0_1.0.8-5build1_amd64",
+					"name": "libbz2-1.0",
+					"version": "1.0.8-5build1"
+				},
+				{
+					"key": "libc6_2.35-0ubuntu3_amd64",
+					"name": "libc6",
+					"version": "2.35-0ubuntu3"
+				},
+				{
+					"key": "libcrypt1_1-4.4.27-1_amd64",
+					"name": "libcrypt1",
+					"version": "1:4.4.27-1"
+				},
+				{
+					"key": "libgcc-s1_12-20220319-1ubuntu1_amd64",
+					"name": "libgcc-s1",
+					"version": "12-20220319-1ubuntu1"
+				},
+				{
+					"key": "liblzma5_5.2.5-2ubuntu1_amd64",
+					"name": "liblzma5",
+					"version": "5.2.5-2ubuntu1"
+				},
+				{
+					"key": "libpcre2-8-0_10.39-3build1_amd64",
+					"name": "libpcre2-8-0",
+					"version": "10.39-3build1"
+				},
+				{
+					"key": "libselinux1_3.3-1build2_amd64",
+					"name": "libselinux1",
+					"version": "3.3-1build2"
+				},
+				{
+					"key": "libzstd1_1.4.8-p-dfsg-3build1_amd64",
+					"name": "libzstd1",
+					"version": "1.4.8+dfsg-3build1"
+				},
+				{
+					"key": "perl-base_5.34.0-3ubuntu1_amd64",
+					"name": "perl-base",
+					"version": "5.34.0-3ubuntu1"
+				},
+				{
+					"key": "tar_1.34-p-dfsg-1build3_amd64",
+					"name": "tar",
+					"version": "1.34+dfsg-1build3"
+				},
+				{
+					"key": "tzdata_2022a-0ubuntu1_amd64",
+					"name": "tzdata",
+					"version": "2022a-0ubuntu1"
+				},
+				{
+					"key": "zlib1g_1-1.2.11.dfsg-2ubuntu9_amd64",
+					"name": "zlib1g",
+					"version": "1:1.2.11.dfsg-2ubuntu9"
+				}
+			],
+			"key": "libtcl8.6_8.6.12-p-dfsg-1build1_amd64",
+			"name": "libtcl8.6",
+			"sha256": "5232b051f9dcd567648ab3061848329ef15cc3a8cb1e66732be80f102dad293c",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20250219T154000Z/pool/main/t/tcl8.6/libtcl8.6_8.6.12+dfsg-1build1_amd64.deb",
+			"version": "8.6.12+dfsg-1build1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libtinfo6_6.3-2_amd64",
+			"name": "libtinfo6",
+			"sha256": "5f7618187c6d1924ec758c2d5422c67377af92ecb21695008edf83a2d0c85ecd",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20250219T154000Z/pool/main/n/ncurses/libtinfo6_6.3-2_amd64.deb",
+			"version": "6.3-2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libxml2_2.9.13-p-dfsg-1build1_amd64",
+			"name": "libxml2",
+			"sha256": "4831826d0e320f6715722716d9737c7e57a052d20e55dd03ff7444c6e502a3ff",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20250219T154000Z/pool/main/libx/libxml2/libxml2_2.9.13+dfsg-1build1_amd64.deb",
+			"version": "2.9.13+dfsg-1build1"
 		},
 		{
 			"arch": "amd64",
@@ -124,6 +590,42 @@
 			"sha256": "ae7db00ce8b093e50c994518b90203544e063b4bc574836a048bb142b950b2c9",
 			"url": "https://snapshot.ubuntu.com/ubuntu/20250219T154000Z/pool/main/libz/libzstd/libzstd1_1.4.8+dfsg-3build1_amd64.deb",
 			"version": "1.4.8+dfsg-3build1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "perl-base_5.34.0-3ubuntu1_amd64",
+			"name": "perl-base",
+			"sha256": "1af46dbc6b00bbcff8b5e72eeedbb2bafdec48bf0d470ce461c1e453c2ecdfe8",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20250219T154000Z/pool/main/p/perl/perl-base_5.34.0-3ubuntu1_amd64.deb",
+			"version": "5.34.0-3ubuntu1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "readline-common_8.1.2-1_amd64",
+			"name": "readline-common",
+			"sha256": "a78d02935f6107a12d3d349c25ce4f92fcdcbf6b65e37f1f5a13a9054b5b9e94",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20250219T154000Z/pool/main/r/readline/readline-common_8.1.2-1_all.deb",
+			"version": "8.1.2-1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "tar_1.34-p-dfsg-1build3_amd64",
+			"name": "tar",
+			"sha256": "d6e4ef9e5793a271764209047ebb78970404b035fd1490cb513302744cfe9a25",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20250219T154000Z/pool/main/t/tar/tar_1.34+dfsg-1build3_amd64.deb",
+			"version": "1.34+dfsg-1build3"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "tzdata_2022a-0ubuntu1_amd64",
+			"name": "tzdata",
+			"sha256": "1fca96a6f5173fa7e448c85b1daae713a7a5e8d2401d189616a20d0d7a807c1d",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20250219T154000Z/pool/main/t/tzdata/tzdata_2022a-0ubuntu1_all.deb",
+			"version": "2022a-0ubuntu1"
 		},
 		{
 			"arch": "amd64",

--- a/deps_24_04.lock.json
+++ b/deps_24_04.lock.json
@@ -4,7 +4,12 @@
 			"amd64"
 		],
 		"packages": [
+			"libdw1t64",
 			"libelf1t64",
+			"libffi8",
+			"libllvm18",
+			"libreadline8t64",
+			"libtcl8.6",
 			"libzstd1",
 			"zlib1g"
 		],
@@ -27,6 +32,15 @@
 		{
 			"arch": "amd64",
 			"dependencies": [],
+			"key": "debconf_1.5.86ubuntu1_amd64",
+			"name": "debconf",
+			"sha256": "bb390da466a7461bfc87aa3e6b7cd145dae84af3e26bf437f2c0c218ba226294",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20250219T154000Z/pool/main/d/debconf/debconf_1.5.86ubuntu1_all.deb",
+			"version": "1.5.86ubuntu1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
 			"key": "gcc-14-base_14-20240412-0ubuntu1_amd64",
 			"name": "gcc-14-base",
 			"sha256": "bc5a682c694a1ce5af50772b7c737a21e9a74f0f0edaae98e97bc9c4af583fef",
@@ -36,11 +50,88 @@
 		{
 			"arch": "amd64",
 			"dependencies": [],
+			"key": "libbsd0_0.12.1-1build1_amd64",
+			"name": "libbsd0",
+			"sha256": "8e97b7d541416512a81e7845c5f21910344c9c5c610893cf265d3298e0caad6b",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20250219T154000Z/pool/main/libb/libbsd/libbsd0_0.12.1-1build1_amd64.deb",
+			"version": "0.12.1-1build1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libbz2-1.0_1.0.8-5.1_amd64",
+			"name": "libbz2-1.0",
+			"sha256": "695132af8a40fe417f7d4e5ea742d64521c04e069442a4719c2bd0f10ab93d94",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20250219T154000Z/pool/main/b/bzip2/libbz2-1.0_1.0.8-5.1_amd64.deb",
+			"version": "1.0.8-5.1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
 			"key": "libc6_2.39-0ubuntu8_amd64",
 			"name": "libc6",
 			"sha256": "af36c7ac770770fe3d3c10e85d6bc538e76e57570ba7db7d397fb9f654783ef3",
 			"url": "https://snapshot.ubuntu.com/ubuntu/20250219T154000Z/pool/main/g/glibc/libc6_2.39-0ubuntu8_amd64.deb",
 			"version": "2.39-0ubuntu8"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [
+				{
+					"key": "gcc-14-base_14-20240412-0ubuntu1_amd64",
+					"name": "gcc-14-base",
+					"version": "14-20240412-0ubuntu1"
+				},
+				{
+					"key": "libbz2-1.0_1.0.8-5.1_amd64",
+					"name": "libbz2-1.0",
+					"version": "1.0.8-5.1"
+				},
+				{
+					"key": "libc6_2.39-0ubuntu8_amd64",
+					"name": "libc6",
+					"version": "2.39-0ubuntu8"
+				},
+				{
+					"key": "libelf1t64_0.190-1.1build4_amd64",
+					"name": "libelf1t64",
+					"version": "0.190-1.1build4"
+				},
+				{
+					"key": "libgcc-s1_14-20240412-0ubuntu1_amd64",
+					"name": "libgcc-s1",
+					"version": "14-20240412-0ubuntu1"
+				},
+				{
+					"key": "liblzma5_5.6.1-p-really5.4.5-1_amd64",
+					"name": "liblzma5",
+					"version": "5.6.1+really5.4.5-1"
+				},
+				{
+					"key": "libzstd1_1.5.5-p-dfsg2-2build1_amd64",
+					"name": "libzstd1",
+					"version": "1.5.5+dfsg2-2build1"
+				},
+				{
+					"key": "zlib1g_1-1.3.dfsg-3.1ubuntu2_amd64",
+					"name": "zlib1g",
+					"version": "1:1.3.dfsg-3.1ubuntu2"
+				}
+			],
+			"key": "libdw1t64_0.190-1.1build4_amd64",
+			"name": "libdw1t64",
+			"sha256": "cdf86260db73ae9f61915fdb898d74a74654ff4b84deeac1c9fe9e5ab2ad83c6",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20250219T154000Z/pool/main/e/elfutils/libdw1t64_0.190-1.1build4_amd64.deb",
+			"version": "0.190-1.1build4"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libedit2_3.1-20230828-1build1_amd64",
+			"name": "libedit2",
+			"sha256": "3afbc8ddf835049dd4d88275b9d13680e4c4cdd59e191cbd63424152cc08e00e",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20250219T154000Z/pool/main/libe/libedit/libedit2_3.1-20230828-1build1_amd64.deb",
+			"version": "3.1-20230828-1build1"
 		},
 		{
 			"arch": "amd64",
@@ -79,12 +170,246 @@
 		},
 		{
 			"arch": "amd64",
+			"dependencies": [
+				{
+					"key": "gcc-14-base_14-20240412-0ubuntu1_amd64",
+					"name": "gcc-14-base",
+					"version": "14-20240412-0ubuntu1"
+				},
+				{
+					"key": "libc6_2.39-0ubuntu8_amd64",
+					"name": "libc6",
+					"version": "2.39-0ubuntu8"
+				},
+				{
+					"key": "libgcc-s1_14-20240412-0ubuntu1_amd64",
+					"name": "libgcc-s1",
+					"version": "14-20240412-0ubuntu1"
+				}
+			],
+			"key": "libffi8_3.4.6-1build1_amd64",
+			"name": "libffi8",
+			"sha256": "637e6a7744de08cd331a41f4efd0d24e6ea9064843dea9d1c6ca87bdb5f038a2",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20250219T154000Z/pool/main/libf/libffi/libffi8_3.4.6-1build1_amd64.deb",
+			"version": "3.4.6-1build1"
+		},
+		{
+			"arch": "amd64",
 			"dependencies": [],
 			"key": "libgcc-s1_14-20240412-0ubuntu1_amd64",
 			"name": "libgcc-s1",
 			"sha256": "a39efdcaa2245f026dc3254ce14fcff255fc430a17064632b6ba7c5da974a912",
 			"url": "https://snapshot.ubuntu.com/ubuntu/20250219T154000Z/pool/main/g/gcc-14/libgcc-s1_14-20240412-0ubuntu1_amd64.deb",
 			"version": "14-20240412-0ubuntu1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libicu74_74.2-1ubuntu3_amd64",
+			"name": "libicu74",
+			"sha256": "d29c97a21a3e3254731cfac186e4d4e611e5e67d2c9a0430f6acfbd9acaefa2e",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20250219T154000Z/pool/main/i/icu/libicu74_74.2-1ubuntu3_amd64.deb",
+			"version": "74.2-1ubuntu3"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [
+				{
+					"key": "gcc-14-base_14-20240412-0ubuntu1_amd64",
+					"name": "gcc-14-base",
+					"version": "14-20240412-0ubuntu1"
+				},
+				{
+					"key": "libbsd0_0.12.1-1build1_amd64",
+					"name": "libbsd0",
+					"version": "0.12.1-1build1"
+				},
+				{
+					"key": "libc6_2.39-0ubuntu8_amd64",
+					"name": "libc6",
+					"version": "2.39-0ubuntu8"
+				},
+				{
+					"key": "libedit2_3.1-20230828-1build1_amd64",
+					"name": "libedit2",
+					"version": "3.1-20230828-1build1"
+				},
+				{
+					"key": "libffi8_3.4.6-1build1_amd64",
+					"name": "libffi8",
+					"version": "3.4.6-1build1"
+				},
+				{
+					"key": "libgcc-s1_14-20240412-0ubuntu1_amd64",
+					"name": "libgcc-s1",
+					"version": "14-20240412-0ubuntu1"
+				},
+				{
+					"key": "libicu74_74.2-1ubuntu3_amd64",
+					"name": "libicu74",
+					"version": "74.2-1ubuntu3"
+				},
+				{
+					"key": "liblzma5_5.6.1-p-really5.4.5-1_amd64",
+					"name": "liblzma5",
+					"version": "5.6.1+really5.4.5-1"
+				},
+				{
+					"key": "libmd0_1.1.0-2build1_amd64",
+					"name": "libmd0",
+					"version": "1.1.0-2build1"
+				},
+				{
+					"key": "libstdc-p--p-6_14-20240412-0ubuntu1_amd64",
+					"name": "libstdc++6",
+					"version": "14-20240412-0ubuntu1"
+				},
+				{
+					"key": "libtinfo6_6.4-p-20240113-1ubuntu2_amd64",
+					"name": "libtinfo6",
+					"version": "6.4+20240113-1ubuntu2"
+				},
+				{
+					"key": "libxml2_2.9.14-p-dfsg-1.3ubuntu3_amd64",
+					"name": "libxml2",
+					"version": "2.9.14+dfsg-1.3ubuntu3"
+				},
+				{
+					"key": "libzstd1_1.5.5-p-dfsg2-2build1_amd64",
+					"name": "libzstd1",
+					"version": "1.5.5+dfsg2-2build1"
+				},
+				{
+					"key": "zlib1g_1-1.3.dfsg-3.1ubuntu2_amd64",
+					"name": "zlib1g",
+					"version": "1:1.3.dfsg-3.1ubuntu2"
+				}
+			],
+			"key": "libllvm18_1-18.1.3-1_amd64",
+			"name": "libllvm18",
+			"sha256": "826621c8e678dd27b4f5c3a9b26d10aae50d5de2d95575695a17c91014f5eaa5",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20250219T154000Z/pool/main/l/llvm-toolchain-18/libllvm18_18.1.3-1_amd64.deb",
+			"version": "1:18.1.3-1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "liblzma5_5.6.1-p-really5.4.5-1_amd64",
+			"name": "liblzma5",
+			"sha256": "28851b3997e4ba74bb3197bd58796bd3041c204c21df85fe0ddafdcaced647f0",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20250219T154000Z/pool/main/x/xz-utils/liblzma5_5.6.1+really5.4.5-1_amd64.deb",
+			"version": "5.6.1+really5.4.5-1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libmd0_1.1.0-2build1_amd64",
+			"name": "libmd0",
+			"sha256": "77f8cdbf03a43656bbf6604e18bd16834fc8bf2c949d4fbdf24ac297869b667a",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20250219T154000Z/pool/main/libm/libmd/libmd0_1.1.0-2build1_amd64.deb",
+			"version": "1.1.0-2build1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [
+				{
+					"key": "gcc-14-base_14-20240412-0ubuntu1_amd64",
+					"name": "gcc-14-base",
+					"version": "14-20240412-0ubuntu1"
+				},
+				{
+					"key": "libc6_2.39-0ubuntu8_amd64",
+					"name": "libc6",
+					"version": "2.39-0ubuntu8"
+				},
+				{
+					"key": "libgcc-s1_14-20240412-0ubuntu1_amd64",
+					"name": "libgcc-s1",
+					"version": "14-20240412-0ubuntu1"
+				},
+				{
+					"key": "libtinfo6_6.4-p-20240113-1ubuntu2_amd64",
+					"name": "libtinfo6",
+					"version": "6.4+20240113-1ubuntu2"
+				},
+				{
+					"key": "readline-common_8.2-4build1_amd64",
+					"name": "readline-common",
+					"version": "8.2-4build1"
+				}
+			],
+			"key": "libreadline8t64_8.2-4build1_amd64",
+			"name": "libreadline8t64",
+			"sha256": "563977a16df03b611f5239cc1e9a0426e86479fcc616b5c9e200ea32063119e5",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20250219T154000Z/pool/main/r/readline/libreadline8t64_8.2-4build1_amd64.deb",
+			"version": "8.2-4build1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libstdc-p--p-6_14-20240412-0ubuntu1_amd64",
+			"name": "libstdc++6",
+			"sha256": "4863e880d6ee538e4734c430c5579c1ac933b88a42c25bc9980d0f148c54b21e",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20250219T154000Z/pool/main/g/gcc-14/libstdc++6_14-20240412-0ubuntu1_amd64.deb",
+			"version": "14-20240412-0ubuntu1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [
+				{
+					"key": "debconf_1.5.86ubuntu1_amd64",
+					"name": "debconf",
+					"version": "1.5.86ubuntu1"
+				},
+				{
+					"key": "gcc-14-base_14-20240412-0ubuntu1_amd64",
+					"name": "gcc-14-base",
+					"version": "14-20240412-0ubuntu1"
+				},
+				{
+					"key": "libc6_2.39-0ubuntu8_amd64",
+					"name": "libc6",
+					"version": "2.39-0ubuntu8"
+				},
+				{
+					"key": "libgcc-s1_14-20240412-0ubuntu1_amd64",
+					"name": "libgcc-s1",
+					"version": "14-20240412-0ubuntu1"
+				},
+				{
+					"key": "tzdata_2024a-2ubuntu1_amd64",
+					"name": "tzdata",
+					"version": "2024a-2ubuntu1"
+				},
+				{
+					"key": "zlib1g_1-1.3.dfsg-3.1ubuntu2_amd64",
+					"name": "zlib1g",
+					"version": "1:1.3.dfsg-3.1ubuntu2"
+				}
+			],
+			"key": "libtcl8.6_8.6.14-p-dfsg-1build1_amd64",
+			"name": "libtcl8.6",
+			"sha256": "7534eb825f6317514d747ce53b4d6c23bf24df1dc1785f9599610ece5515e685",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20250219T154000Z/pool/main/t/tcl8.6/libtcl8.6_8.6.14+dfsg-1build1_amd64.deb",
+			"version": "8.6.14+dfsg-1build1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libtinfo6_6.4-p-20240113-1ubuntu2_amd64",
+			"name": "libtinfo6",
+			"sha256": "53e1e1753729d04cf65b05e6e58abe06e2bb76cc07eff0e1b2a638a638ca209b",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20250219T154000Z/pool/main/n/ncurses/libtinfo6_6.4+20240113-1ubuntu2_amd64.deb",
+			"version": "6.4+20240113-1ubuntu2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libxml2_2.9.14-p-dfsg-1.3ubuntu3_amd64",
+			"name": "libxml2",
+			"sha256": "8c4efd7abe155df3cf0f9b64d659f2d866215785f8e8c44234fbb341d58cc967",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20250219T154000Z/pool/main/libx/libxml2/libxml2_2.9.14+dfsg-1.3ubuntu3_amd64.deb",
+			"version": "2.9.14+dfsg-1.3ubuntu3"
 		},
 		{
 			"arch": "amd64",
@@ -110,6 +435,24 @@
 			"sha256": "4dcc3ba9606a5837a55248d08162a5b426dd621f75c0eb24d86409e0d0e71d52",
 			"url": "https://snapshot.ubuntu.com/ubuntu/20250219T154000Z/pool/main/libz/libzstd/libzstd1_1.5.5+dfsg2-2build1_amd64.deb",
 			"version": "1.5.5+dfsg2-2build1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "readline-common_8.2-4build1_amd64",
+			"name": "readline-common",
+			"sha256": "879bfd7f8a9bc4c0f7cdc777cdd8bc6de5f8c4a2ac80c060322a1b22f13504bb",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20250219T154000Z/pool/main/r/readline/readline-common_8.2-4build1_all.deb",
+			"version": "8.2-4build1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "tzdata_2024a-2ubuntu1_amd64",
+			"name": "tzdata",
+			"sha256": "f5bca0c788a4fc465c435f7e8a54b2594e9cbf1a22abb263a59e393f1cb666e1",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20250219T154000Z/pool/main/t/tzdata/tzdata_2024a-2ubuntu1_all.deb",
+			"version": "2024a-2ubuntu1"
 		},
 		{
 			"arch": "amd64",

--- a/internal/config/BUILD.bazel
+++ b/internal/config/BUILD.bazel
@@ -2,7 +2,7 @@ load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
 
 string_flag(
     name = "ubuntu_version",
-    build_setting_default = "22.04",
+    build_setting_default = "24.04",
     values = ["22.04", "24.04"],
     visibility = ["//visibility:public"],
 )

--- a/internal/toolchain.bzl
+++ b/internal/toolchain.bzl
@@ -2,6 +2,7 @@ load("//internal:providers.bzl", "NVCInfo")
 
 NVC_TOOLCHAIN_TYPE = "@rules_nvc//build/nvc:toolchain_type"
 NVC_WRAPPER = Label("@rules_nvc//build/nvc:nvc_wrapper")
+NVC_DIRECT_WRAPPER = Label("@rules_nvc//build/nvc:nvc_direct_wrapper")
 VHDL_STANDARD_DEFAULT = "2019"
 
 STANDARD_TO_SUFFIX = {

--- a/internal/utils.bzl
+++ b/internal/utils.bzl
@@ -28,6 +28,7 @@ def get_nvc_ld_library_path(nvc_info, base_dir, default_env):
             if ".so" in dep.basename:
                 paths[dep.dirname] = True
     ld_path = ":".join(paths.keys())
+    print("LD_PATH IS:", ld_path)
     if default_env.get("LD_LIBRARY_PATH", ""):
         ld_path += ":" + default_env.get("LD_LIBRARY_PATH", "")
     return ld_path

--- a/internal/verilog_library.bzl
+++ b/internal/verilog_library.bzl
@@ -1,14 +1,16 @@
-load("//internal:utils.bzl", "get_single_file_from")
+load("//internal:utils.bzl", "get_single_file_from", "get_nvc_deps", "get_nvc_ld_library_path")
 load("//internal:providers.bzl", "NVCInfo", "VHDLLibraryProvider", "ElaborateProvider")
 load("//internal:toolchain.bzl",
      _NVC_TOOLCHAIN_TYPE = "NVC_TOOLCHAIN_TYPE",
      _NVC_WRAPPER = "NVC_WRAPPER",
+     _NVC_DIRECT_WRAPPER = "NVC_DIRECT_WRAPPER",
     _VHDL_STANDARD_DEFAULT = "VHDL_STANDARD_DEFAULT",
     _nvc_toolchain = "nvc_toolchain")
 
 
 def _impl(ctx):
     nvc_info = ctx.toolchains[_NVC_TOOLCHAIN_TYPE].nvc_info
+    nvc_deps = get_nvc_deps(nvc_info)
     analyzer_x = nvc_info.analyzer.files.to_list()[0]
     analyzer = analyzer_x.path
     library_name = ctx.attr.library_name or ctx.attr.name
@@ -18,6 +20,10 @@ def _impl(ctx):
 
     artifacts = nvc_info.artifacts_dir.files.to_list()
     std_lib_dir = artifacts[1] # hopefully stable...
+    
+    analyzer_dir = analyzer_x.dirname
+    base_dir = analyzer_dir[:-4] if analyzer_dir.endswith("/bin") else analyzer_dir
+
     targets = ctx.attr.srcs
     srcs = []
     for target in targets:
@@ -55,9 +61,13 @@ def _impl(ctx):
 
     ctx.actions.run(
         outputs = [container_dir],
-        inputs = srcs + deps_files + ctx.files.hdrs + all_hdrs_files,
-        executable =  analyzer, # how do I get its path?
+        inputs = srcs + deps_files + ctx.files.hdrs + all_hdrs_files + nvc_deps,
+        executable = ctx.executable._direct_wrapper,
+        env = {
+            "NVC_LD_LIBRARY_PATH": get_nvc_ld_library_path(nvc_info, base_dir, ctx.configuration.default_shell_env),
+        },
         arguments = [
+          analyzer,
           "--std={}".format(ctx.attr.standard),
           "-L", "{}/nvc".format(std_lib_dir.path),
         ] + flag_libraries + [
@@ -114,9 +124,13 @@ verilog_library = rule(
         "includes": attr.string_list(
             doc = "list of verilog include directories",
         ),
+        "_direct_wrapper": attr.label(
+            default = _NVC_DIRECT_WRAPPER,
+            executable = True,
+            cfg = "host",
+        ),
     },
     toolchains = [
         _NVC_TOOLCHAIN_TYPE,
     ],
 )
-

--- a/internal/vhdl_library.bzl
+++ b/internal/vhdl_library.bzl
@@ -3,6 +3,7 @@ load("//internal:providers.bzl", "NVCInfo", "VHDLLibraryProvider", "ElaboratePro
 load("//internal:toolchain.bzl",
      _NVC_TOOLCHAIN_TYPE = "NVC_TOOLCHAIN_TYPE",
      _NVC_WRAPPER = "NVC_WRAPPER",
+     _NVC_DIRECT_WRAPPER = "NVC_DIRECT_WRAPPER",
     _VHDL_STANDARD_DEFAULT = "VHDL_STANDARD_DEFAULT",
     _nvc_toolchain = "nvc_toolchain")
 
@@ -70,11 +71,12 @@ def _vhdl_library(ctx):
     ctx.actions.run(
         outputs = [container_dir],
         inputs = srcs + deps_files + nvc_deps,
-        executable =  analyzer, # how do I get its path?
+        executable = ctx.executable._direct_wrapper,
         env = {
             "NVC_LD_LIBRARY_PATH": get_nvc_ld_library_path(nvc_info, base_dir, ctx.configuration.default_shell_env),
         },
         arguments = [
+          analyzer,
           "--std={}".format(ctx.attr.standard),
           "-L", nvc_lib_path,
         ] + flag_libraries + [
@@ -125,6 +127,11 @@ vhdl_library = rule(
         "vpi_plugins": attr.label_list(
             allow_files = True,
             doc = "List of VPI plugins required for simulation.",
+        ),
+        "_direct_wrapper": attr.label(
+            default = _NVC_DIRECT_WRAPPER,
+            executable = True,
+            cfg = "host",
         ),
     },
     toolchains = [

--- a/internal/vhdl_run.bzl
+++ b/internal/vhdl_run.bzl
@@ -101,6 +101,10 @@ def _vhdl_run(ctx):
         base_dir_for_wrapper = "../" + base_dir[9:]
 
     nvc_ld_library_path = get_nvc_ld_library_path(nvc_info, base_dir, ctx.configuration.default_shell_env)
+    nvc_ld_library_path_for_wrapper = ":".join([
+        ("../" + p[9:]) if p.startswith("external/") else p
+        for p in nvc_ld_library_path.split(":")
+    ])
     
     # Prefix external paths for NVC_LD_LIBRARY_PATH if needed
     # (Just passing the literal value for now, we can adapt the NVC wrapper or base_dir if needed)
@@ -109,7 +113,7 @@ def _vhdl_run(ctx):
         template = ctx.file._template,
         output = ctx.outputs.executable,
         substitutions = {
-            "{{EXECUTABLE}}": "NVC_LD_LIBRARY_PATH=\"" + nvc_ld_library_path + "\" LD_LIBRARY_PATH=\"" + base_dir_for_wrapper + "/lib/x86_64-linux-gnu\" " + ctx.executable._script.short_path,
+            "{{EXECUTABLE}}": "NVC_LD_LIBRARY_PATH=\"" + nvc_ld_library_path_for_wrapper + "\" LD_LIBRARY_PATH=\"" + base_dir_for_wrapper + "/lib/x86_64-linux-gnu\" " + ctx.executable._script.short_path,
             "{{VHDL_STANDARD}}": ctx.attr.standard,
             "{{ANALYZER}}": analyzer_for_wrapper,
             "{{LIBRARY_NAME}}": vhdl_provider.library_name,

--- a/internal/vhdl_test.bzl
+++ b/internal/vhdl_test.bzl
@@ -1,4 +1,4 @@
-load("//internal:utils.bzl", "get_single_file_from")
+load("//internal:utils.bzl", "get_single_file_from", "get_nvc_ld_library_path")
 load("//internal:providers.bzl", "NVCInfo", "VHDLLibraryProvider", "ElaborateProvider")
 load("//internal:toolchain.bzl",
      _NVC_TOOLCHAIN_TYPE = "NVC_TOOLCHAIN_TYPE",
@@ -96,11 +96,17 @@ def _vhdl_test(ctx):
     if base_dir.startswith("external/"):
         base_dir_for_wrapper = "../" + base_dir[9:]
 
+    nvc_ld_library_path = get_nvc_ld_library_path(nvc_info, base_dir, ctx.configuration.default_shell_env)
+    nvc_ld_library_path_for_wrapper = ":".join([
+        ("../" + p[9:]) if p.startswith("external/") else p
+        for p in nvc_ld_library_path.split(":")
+    ])
+
     ctx.actions.expand_template(
         template = ctx.file._template,
         output = ctx.outputs.executable,
         substitutions = {
-            "{{EXECUTABLE}}": "LD_LIBRARY_PATH=\"" + base_dir_for_wrapper + "/lib/x86_64-linux-gnu\" " + ctx.executable._script.short_path,
+            "{{EXECUTABLE}}": "NVC_LD_LIBRARY_PATH=\"" + nvc_ld_library_path_for_wrapper + "\" LD_LIBRARY_PATH=\"" + base_dir_for_wrapper + "/lib/x86_64-linux-gnu\" " + ctx.executable._script.short_path,
             "{{VHDL_STANDARD}}": ctx.attr.standard,
             "{{ANALYZER}}": analyzer_for_wrapper,
             "{{LIBRARY_NAME}}": vhdl_provider.library_name,

--- a/third_party/nvc/BUILD.bazel
+++ b/third_party/nvc/BUILD.bazel
@@ -2,13 +2,19 @@ package(default_visibility = ["//visibility:public"])
 
 filegroup(
     name = "nvc_repo",
-    srcs = ["@nvc_deb//:all_files"],
+    srcs = select({
+        "//internal/config:ubuntu_24_04": ["@nvc_deb_24_04//:all_files"],
+        "//conditions:default": ["@nvc_deb_22_04//:all_files"],
+    }),
     visibility = ["//visibility:public"],
 )
 
 filegroup(
     name = "compiler",
-    srcs = ["@nvc_deb//:usr/bin/nvc"],
+    srcs = select({
+        "//internal/config:ubuntu_24_04": ["@nvc_deb_24_04//:usr/bin/nvc"],
+        "//conditions:default": ["@nvc_deb_22_04//:usr/bin/nvc"],
+    }),
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
Updating the default ubuntu_version to 24.04 ensures that when the GitHub Actions runner (ubuntu-latest) compiles VPI plugins using the host's C++ toolchain (which uses GLIBC 2.38), the sandboxed NVC runtime uses a matching GLIBC from deps_24_04. This prevents `version 'GLIBC_2.38' not found` errors when NVC attempts to load the host-compiled plugins.

This pull request has been created by an automated coding assistant, with human supervision.
Prompt: and again: ERROR: ... VHDL analyze: sim failed ... GLIBC_2.38 not found