### PR TITLE
feat(vhdl)!: integrate rules_vhdl and standardize rule names

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -70,3 +70,5 @@ register_toolchains(
     "@toolchains//:toolchainlinux_x86_64linux_x86_64",
     dev_dependency = True,
 )
+
+bazel_dep(name = "rules_vhdl", version = "0.1.2")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -296,6 +296,8 @@
     "https://bcr.bazel.build/modules/rules_verilog/1.1.0/MODULE.bazel": "7b1d2d0321566572b61b76a4b4c263ce4da27ee0437552e1c70cff838101db57",
     "https://bcr.bazel.build/modules/rules_verilog/1.1.1/MODULE.bazel": "adcccf08f92e16936d6aa2e872f31a79e80712333be604de750d4b109fae1519",
     "https://bcr.bazel.build/modules/rules_verilog/1.1.1/source.json": "32a02fe6f97e1a233cff48e0eae70243e2e25d4c57fc684f933e06ef67440d8b",
+    "https://bcr.bazel.build/modules/rules_vhdl/0.1.2/MODULE.bazel": "03410b3c95f5832339a8a9f737d1a07bd57dd411d965425fb3bec4fdc4dd107f",
+    "https://bcr.bazel.build/modules/rules_vhdl/0.1.2/source.json": "2427af347389f8867f4d6a358a96233226a9077f6502945f4e2f8a70d7f69aab",
     "https://bcr.bazel.build/modules/stardoc/0.5.1/MODULE.bazel": "1a05d92974d0c122f5ccf09291442580317cdd859f07a8655f1db9a60374f9f8",
     "https://bcr.bazel.build/modules/stardoc/0.5.3/MODULE.bazel": "c7f6948dae6999bf0db32c1858ae345f112cacf98f174c7a8bb707e41b974f1c",
     "https://bcr.bazel.build/modules/stardoc/0.6.2/MODULE.bazel": "7060193196395f5dd668eda046ccbeacebfd98efc77fed418dbe2b82ffaa39fd",
@@ -574,6 +576,7 @@
     "https://raw.githubusercontent.com/filmil/bazel-registry/main/modules/rules_verilator/1.0.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/filmil/bazel-registry/main/modules/rules_verilog/1.1.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/filmil/bazel-registry/main/modules/rules_verilog/1.1.1/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/filmil/bazel-registry/main/modules/rules_vhdl/0.1.2/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/filmil/bazel-registry/main/modules/stardoc/0.5.1/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/filmil/bazel-registry/main/modules/stardoc/0.5.3/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/filmil/bazel-registry/main/modules/stardoc/0.6.2/MODULE.bazel": "not found",
@@ -595,6 +598,218 @@
     "https://raw.githubusercontent.com/filmil/bazel-registry/main/modules/zlib/1.3.1/MODULE.bazel": "not found"
   },
   "selectedYankedVersions": {},
-  "moduleExtensions": {},
+  "moduleExtensions": {
+    "@@rules_android+//rules/android_sdk_repository:rule.bzl%android_sdk_repository_extension": {
+      "general": {
+        "bzlTransitiveDigest": "qHbR00gVzVzkxX+PRtv4UGcUFMtBz7TK9CNYUWH8nIE=",
+        "usagesDigest": "tTIw/WMyb1t/LzacDY8lDjUznzxQ3MyXW6474WIS3WQ=",
+        "recordedInputs": [],
+        "generatedRepoSpecs": {
+          "androidsdk": {
+            "repoRuleId": "@@rules_android+//rules/android_sdk_repository:rule.bzl%_android_sdk_repository",
+            "attributes": {}
+          }
+        }
+      }
+    },
+    "@@rules_python+//python/extensions:config.bzl%config": {
+      "general": {
+        "bzlTransitiveDigest": "2hLgIvNVTLgxus0ZuXtleBe70intCfo0cHs8qvt6cdM=",
+        "usagesDigest": "ZVSXMAGpD+xzVNPuvF1IoLBkty7TROO0+akMapt1pAg=",
+        "recordedInputs": [
+          "REPO_MAPPING:rules_python+,bazel_tools bazel_tools",
+          "REPO_MAPPING:rules_python+,pypi__build rules_python++config+pypi__build",
+          "REPO_MAPPING:rules_python+,pypi__click rules_python++config+pypi__click",
+          "REPO_MAPPING:rules_python+,pypi__colorama rules_python++config+pypi__colorama",
+          "REPO_MAPPING:rules_python+,pypi__importlib_metadata rules_python++config+pypi__importlib_metadata",
+          "REPO_MAPPING:rules_python+,pypi__installer rules_python++config+pypi__installer",
+          "REPO_MAPPING:rules_python+,pypi__more_itertools rules_python++config+pypi__more_itertools",
+          "REPO_MAPPING:rules_python+,pypi__packaging rules_python++config+pypi__packaging",
+          "REPO_MAPPING:rules_python+,pypi__pep517 rules_python++config+pypi__pep517",
+          "REPO_MAPPING:rules_python+,pypi__pip rules_python++config+pypi__pip",
+          "REPO_MAPPING:rules_python+,pypi__pip_tools rules_python++config+pypi__pip_tools",
+          "REPO_MAPPING:rules_python+,pypi__pyproject_hooks rules_python++config+pypi__pyproject_hooks",
+          "REPO_MAPPING:rules_python+,pypi__setuptools rules_python++config+pypi__setuptools",
+          "REPO_MAPPING:rules_python+,pypi__tomli rules_python++config+pypi__tomli",
+          "REPO_MAPPING:rules_python+,pypi__wheel rules_python++config+pypi__wheel",
+          "REPO_MAPPING:rules_python+,pypi__zipp rules_python++config+pypi__zipp"
+        ],
+        "generatedRepoSpecs": {
+          "rules_python_internal": {
+            "repoRuleId": "@@rules_python+//python/private:internal_config_repo.bzl%internal_config_repo",
+            "attributes": {
+              "transition_setting_generators": {},
+              "transition_settings": []
+            }
+          },
+          "pypi__build": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://files.pythonhosted.org/packages/e2/03/f3c8ba0a6b6e30d7d18c40faab90807c9bb5e9a1e3b2fe2008af624a9c97/build-1.2.1-py3-none-any.whl",
+              "sha256": "75e10f767a433d9a86e50d83f418e83efc18ede923ee5ff7df93b6cb0306c5d4",
+              "type": "zip",
+              "build_file_content": "package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:py_library.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude to avoid non-determinism.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"
+            }
+          },
+          "pypi__click": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://files.pythonhosted.org/packages/00/2e/d53fa4befbf2cfa713304affc7ca780ce4fc1fd8710527771b58311a3229/click-8.1.7-py3-none-any.whl",
+              "sha256": "ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28",
+              "type": "zip",
+              "build_file_content": "package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:py_library.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude to avoid non-determinism.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"
+            }
+          },
+          "pypi__colorama": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl",
+              "sha256": "4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6",
+              "type": "zip",
+              "build_file_content": "package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:py_library.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude to avoid non-determinism.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"
+            }
+          },
+          "pypi__importlib_metadata": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://files.pythonhosted.org/packages/2d/0a/679461c511447ffaf176567d5c496d1de27cbe34a87df6677d7171b2fbd4/importlib_metadata-7.1.0-py3-none-any.whl",
+              "sha256": "30962b96c0c223483ed6cc7280e7f0199feb01a0e40cfae4d4450fc6fab1f570",
+              "type": "zip",
+              "build_file_content": "package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:py_library.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude to avoid non-determinism.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"
+            }
+          },
+          "pypi__installer": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://files.pythonhosted.org/packages/e5/ca/1172b6638d52f2d6caa2dd262ec4c811ba59eee96d54a7701930726bce18/installer-0.7.0-py3-none-any.whl",
+              "sha256": "05d1933f0a5ba7d8d6296bb6d5018e7c94fa473ceb10cf198a92ccea19c27b53",
+              "type": "zip",
+              "build_file_content": "package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:py_library.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude to avoid non-determinism.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"
+            }
+          },
+          "pypi__more_itertools": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://files.pythonhosted.org/packages/50/e2/8e10e465ee3987bb7c9ab69efb91d867d93959095f4807db102d07995d94/more_itertools-10.2.0-py3-none-any.whl",
+              "sha256": "686b06abe565edfab151cb8fd385a05651e1fdf8f0a14191e4439283421f8684",
+              "type": "zip",
+              "build_file_content": "package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:py_library.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude to avoid non-determinism.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"
+            }
+          },
+          "pypi__packaging": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://files.pythonhosted.org/packages/49/df/1fceb2f8900f8639e278b056416d49134fb8d84c5942ffaa01ad34782422/packaging-24.0-py3-none-any.whl",
+              "sha256": "2ddfb553fdf02fb784c234c7ba6ccc288296ceabec964ad2eae3777778130bc5",
+              "type": "zip",
+              "build_file_content": "package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:py_library.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude to avoid non-determinism.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"
+            }
+          },
+          "pypi__pep517": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://files.pythonhosted.org/packages/25/6e/ca4a5434eb0e502210f591b97537d322546e4833dcb4d470a48c375c5540/pep517-0.13.1-py3-none-any.whl",
+              "sha256": "31b206f67165b3536dd577c5c3f1518e8fbaf38cbc57efff8369a392feff1721",
+              "type": "zip",
+              "build_file_content": "package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:py_library.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude to avoid non-determinism.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"
+            }
+          },
+          "pypi__pip": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://files.pythonhosted.org/packages/8a/6a/19e9fe04fca059ccf770861c7d5721ab4c2aebc539889e97c7977528a53b/pip-24.0-py3-none-any.whl",
+              "sha256": "ba0d021a166865d2265246961bec0152ff124de910c5cc39f1156ce3fa7c69dc",
+              "type": "zip",
+              "build_file_content": "package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:py_library.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude to avoid non-determinism.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"
+            }
+          },
+          "pypi__pip_tools": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://files.pythonhosted.org/packages/0d/dc/38f4ce065e92c66f058ea7a368a9c5de4e702272b479c0992059f7693941/pip_tools-7.4.1-py3-none-any.whl",
+              "sha256": "4c690e5fbae2f21e87843e89c26191f0d9454f362d8acdbd695716493ec8b3a9",
+              "type": "zip",
+              "build_file_content": "package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:py_library.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude to avoid non-determinism.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"
+            }
+          },
+          "pypi__pyproject_hooks": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://files.pythonhosted.org/packages/ae/f3/431b9d5fe7d14af7a32340792ef43b8a714e7726f1d7b69cc4e8e7a3f1d7/pyproject_hooks-1.1.0-py3-none-any.whl",
+              "sha256": "7ceeefe9aec63a1064c18d939bdc3adf2d8aa1988a510afec15151578b232aa2",
+              "type": "zip",
+              "build_file_content": "package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:py_library.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude to avoid non-determinism.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"
+            }
+          },
+          "pypi__setuptools": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://files.pythonhosted.org/packages/90/99/158ad0609729111163fc1f674a5a42f2605371a4cf036d0441070e2f7455/setuptools-78.1.1-py3-none-any.whl",
+              "sha256": "c3a9c4211ff4c309edb8b8c4f1cbfa7ae324c4ba9f91ff254e3d305b9fd54561",
+              "type": "zip",
+              "build_file_content": "package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:py_library.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude to avoid non-determinism.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"
+            }
+          },
+          "pypi__tomli": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://files.pythonhosted.org/packages/97/75/10a9ebee3fd790d20926a90a2547f0bf78f371b2f13aa822c759680ca7b9/tomli-2.0.1-py3-none-any.whl",
+              "sha256": "939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
+              "type": "zip",
+              "build_file_content": "package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:py_library.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude to avoid non-determinism.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"
+            }
+          },
+          "pypi__wheel": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://files.pythonhosted.org/packages/7d/cd/d7460c9a869b16c3dd4e1e403cce337df165368c71d6af229a74699622ce/wheel-0.43.0-py3-none-any.whl",
+              "sha256": "55c570405f142630c6b9f72fe09d9b67cf1477fcf543ae5b8dcb1f5b7377da81",
+              "type": "zip",
+              "build_file_content": "package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:py_library.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude to avoid non-determinism.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"
+            }
+          },
+          "pypi__zipp": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://files.pythonhosted.org/packages/da/55/a03fd7240714916507e1fcf7ae355bd9d9ed2e6db492595f1a67f61681be/zipp-3.18.2-py3-none-any.whl",
+              "sha256": "dce197b859eb796242b0622af1b8beb0a722d52aa2f57133ead08edd5bf5374e",
+              "type": "zip",
+              "build_file_content": "package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:py_library.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude to avoid non-determinism.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"
+            }
+          }
+        }
+      }
+    },
+    "@@rules_python+//python/uv:uv.bzl%uv": {
+      "general": {
+        "bzlTransitiveDigest": "ijW9KS7qsIY+yBVvJ+Nr1mzwQox09j13DnE3iIwaeTM=",
+        "usagesDigest": "H8dQoNZcoqP+Mu0tHZTi4KHATzvNkM5ePuEqoQdklIU=",
+        "recordedInputs": [
+          "REPO_MAPPING:rules_python+,bazel_tools bazel_tools",
+          "REPO_MAPPING:rules_python+,platforms platforms"
+        ],
+        "generatedRepoSpecs": {
+          "uv": {
+            "repoRuleId": "@@rules_python+//python/uv/private:uv_toolchains_repo.bzl%uv_toolchains_repo",
+            "attributes": {
+              "toolchain_type": "'@@rules_python+//python/uv:uv_toolchain_type'",
+              "toolchain_names": [
+                "none"
+              ],
+              "toolchain_implementations": {
+                "none": "'@@rules_python+//python:none'"
+              },
+              "toolchain_compatible_with": {
+                "none": [
+                  "@platforms//:incompatible"
+                ]
+              },
+              "toolchain_target_settings": {}
+            }
+          }
+        }
+      }
+    }
+  },
   "facts": {}
 }

--- a/build/nvc/BUILD.bazel
+++ b/build/nvc/BUILD.bazel
@@ -86,16 +86,17 @@ bzl_library(
     deps = [
         "//internal:extract_file",
         "//internal:macros",
+        "//internal:nvc_verilog_library",
+        "//internal:nvc_vhdl_elaborate",
+        "//internal:nvc_vhdl_library",
+        "//internal:nvc_vhdl_run",
+        "//internal:nvc_vhdl_test",
         "//internal:prebuilt_library",
         "//internal:produce_waveform",
         "//internal:providers",
+        "//internal:rules_vhdl_defs",
         "//internal:toolchain",
         "//internal:utils",
-        "//internal:verilog_library",
-        "//internal:vhdl_elaborate",
-        "//internal:vhdl_library",
-        "//internal:vhdl_run",
-        "//internal:vhdl_test",
     ],
 )
 

--- a/build/nvc/rules.bzl
+++ b/build/nvc/rules.bzl
@@ -11,25 +11,25 @@ load("//internal:extract_file.bzl", _extract_file = "extract_file")
 load("//internal:macros.bzl", _wave_view = "wave_view")
 load("//internal:prebuilt_library.bzl", _prebuilt_library = "prebuilt_library")
 load("//internal:produce_waveform.bzl", _produce_waveform = "produce_waveform")
-load("//internal:vhdl_elaborate.bzl", _vhdl_elaborate = "vhdl_elaborate")
-load("//internal:vhdl_library.bzl", _vhdl_library = "vhdl_library")
-load("//internal:vhdl_run.bzl", _vhdl_run = "vhdl_run")
-load("//internal:vhdl_test.bzl", _vhdl_test = "vhdl_test")
+load("//internal:nvc_vhdl_elaborate.bzl", _nvc_vhdl_elaborate = "nvc_vhdl_elaborate")
+load("//internal:nvc_vhdl_library.bzl", _nvc_vhdl_library = "nvc_vhdl_library")
+load("//internal:nvc_vhdl_run.bzl", _nvc_vhdl_run = "nvc_vhdl_run")
+load("//internal:nvc_vhdl_test.bzl", _nvc_vhdl_test = "nvc_vhdl_test")
 
-load("//internal:verilog_library.bzl", _verilog_library = "verilog_library")
+load("//internal:nvc_verilog_library.bzl", _nvc_verilog_library = "nvc_verilog_library")
 
 
 # The main API
 nvc_toolchain = _nvc_toolchain
-vhdl_library = _vhdl_library
-vhdl_elaborate = _vhdl_elaborate
-vhdl_run = _vhdl_run
+nvc_vhdl_library = _nvc_vhdl_library
+nvc_vhdl_elaborate = _nvc_vhdl_elaborate
+nvc_vhdl_run = _nvc_vhdl_run
 produce_waveform = _produce_waveform
 extract_file = _extract_file
 prebuilt_library = _prebuilt_library
-vhdl_test = _vhdl_test
+nvc_vhdl_test = _nvc_vhdl_test
 
-verilog_library = _verilog_library
+nvc_verilog_library = _nvc_verilog_library
 
 
 # Macros

--- a/build/nvc/rules.md
+++ b/build/nvc/rules.md
@@ -47,6 +47,107 @@ Defines the NVC toolchain, linking to the NVC analyzer and standard library.
 | <a id="nvc_toolchain-artifacts_dir"></a>artifacts_dir |  The directory containing NVC standard libraries and artifacts.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
 
 
+<a id="nvc_verilog_library"></a>
+
+## nvc_verilog_library
+
+<pre>
+load("@rules_nvc//build/nvc:rules.bzl", "nvc_verilog_library")
+
+nvc_verilog_library(<a href="#nvc_verilog_library-name">name</a>, <a href="#nvc_verilog_library-deps">deps</a>, <a href="#nvc_verilog_library-srcs">srcs</a>, <a href="#nvc_verilog_library-hdrs">hdrs</a>, <a href="#nvc_verilog_library-entities">entities</a>, <a href="#nvc_verilog_library-includes">includes</a>, <a href="#nvc_verilog_library-library_name">library_name</a>, <a href="#nvc_verilog_library-standard">standard</a>)
+</pre>
+
+Compiles Verilog source files into a library using NVC.
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="nvc_verilog_library-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="nvc_verilog_library-deps"></a>deps |  List of dependency libraries.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="nvc_verilog_library-srcs"></a>srcs |  List of Verilog source files.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="nvc_verilog_library-hdrs"></a>hdrs |  List of Verilog header files.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="nvc_verilog_library-entities"></a>entities |  List of entities provided by this library.   | List of strings | optional |  `[]`  |
+| <a id="nvc_verilog_library-includes"></a>includes |  list of verilog include directories   | List of strings | optional |  `[]`  |
+| <a id="nvc_verilog_library-library_name"></a>library_name |  If the target name is not appropriate as a library name, provide one here   | String | optional |  `""`  |
+| <a id="nvc_verilog_library-standard"></a>standard |  The VHDL standard to use for compilation.   | String | optional |  `"2019"`  |
+
+
+<a id="nvc_vhdl_elaborate"></a>
+
+## nvc_vhdl_elaborate
+
+<pre>
+load("@rules_nvc//build/nvc:rules.bzl", "nvc_vhdl_elaborate")
+
+nvc_vhdl_elaborate(<a href="#nvc_vhdl_elaborate-name">name</a>, <a href="#nvc_vhdl_elaborate-library">library</a>, <a href="#nvc_vhdl_elaborate-standard">standard</a>)
+</pre>
+
+Elaborates a VHDL design using NVC.
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="nvc_vhdl_elaborate-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="nvc_vhdl_elaborate-library"></a>library |  The `nvc_vhdl_library` target to elaborate.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
+| <a id="nvc_vhdl_elaborate-standard"></a>standard |  The VHDL standard to use for elaboration (e.g., '2019').   | String | optional |  `"2019"`  |
+
+
+<a id="nvc_vhdl_library"></a>
+
+## nvc_vhdl_library
+
+<pre>
+load("@rules_nvc//build/nvc:rules.bzl", "nvc_vhdl_library")
+
+nvc_vhdl_library(<a href="#nvc_vhdl_library-name">name</a>, <a href="#nvc_vhdl_library-deps">deps</a>, <a href="#nvc_vhdl_library-srcs">srcs</a>, <a href="#nvc_vhdl_library-entities">entities</a>, <a href="#nvc_vhdl_library-library_name">library_name</a>, <a href="#nvc_vhdl_library-standard">standard</a>, <a href="#nvc_vhdl_library-vpi_plugins">vpi_plugins</a>)
+</pre>
+
+Compiles VHDL source files into a library using NVC.
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="nvc_vhdl_library-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="nvc_vhdl_library-deps"></a>deps |  A list of other `nvc_vhdl_library` targets that this library depends on.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="nvc_vhdl_library-srcs"></a>srcs |  A list of VHDL source files.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="nvc_vhdl_library-entities"></a>entities |  A list of VHDL entities provided by this library.   | List of strings | optional |  `[]`  |
+| <a id="nvc_vhdl_library-library_name"></a>library_name |  If the target name is not appropriate as a library name, provide one here   | String | optional |  `""`  |
+| <a id="nvc_vhdl_library-standard"></a>standard |  The VHDL standard to use for compilation (e.g., '2008', '2019'). Defaults to '2019'.   | String | optional |  `"2019"`  |
+| <a id="nvc_vhdl_library-vpi_plugins"></a>vpi_plugins |  List of VPI plugins required for simulation.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+
+
+<a id="nvc_vhdl_run"></a>
+
+## nvc_vhdl_run
+
+<pre>
+load("@rules_nvc//build/nvc:rules.bzl", "nvc_vhdl_run")
+
+nvc_vhdl_run(<a href="#nvc_vhdl_run-name">name</a>, <a href="#nvc_vhdl_run-deps">deps</a>, <a href="#nvc_vhdl_run-args">args</a>, <a href="#nvc_vhdl_run-entity">entity</a>, <a href="#nvc_vhdl_run-standard">standard</a>, <a href="#nvc_vhdl_run-use_fst">use_fst</a>, <a href="#nvc_vhdl_run-use_vcd">use_vcd</a>)
+</pre>
+
+Simulates an elaborated VHDL design using NVC.
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="nvc_vhdl_run-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="nvc_vhdl_run-deps"></a>deps |  A list of other `nvc_vhdl_library` targets that this simulation depends on.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="nvc_vhdl_run-args"></a>args |  A list of added command line args to use   | List of strings | optional |  `[]`  |
+| <a id="nvc_vhdl_run-entity"></a>entity |  The elaborated VHDL entity to simulate. This should be a `nvc_vhdl_elaborate` target.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
+| <a id="nvc_vhdl_run-standard"></a>standard |  The VHDL standard to use for simulation. Defaults to '2019'.   | String | optional |  `"2019"`  |
+| <a id="nvc_vhdl_run-use_fst"></a>use_fst |  A boolean indicating whether to generate a FST file for waveform viewing. Defaults to `False`. Takes precedence over `use_vcd`.   | Boolean | optional |  `False`  |
+| <a id="nvc_vhdl_run-use_vcd"></a>use_vcd |  A boolean indicating whether to generate a VCD (Value Change Dump) file for waveform viewing. Defaults to `True`.   | Boolean | optional |  `True`  |
+
+
 <a id="prebuilt_library"></a>
 
 ## prebuilt_library
@@ -95,124 +196,23 @@ Produces a waveform file (VCD) from a VHDL simulation run.
 | <a id="produce_waveform-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
 | <a id="produce_waveform-data"></a>data |  Data files required for the simulation.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="produce_waveform-args"></a>args |  Additional command-line arguments to pass to the simulation.   | List of strings | optional |  `[]`  |
-| <a id="produce_waveform-simulation"></a>simulation |  The simulation target (`vhdl_run`) to execute.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
+| <a id="produce_waveform-simulation"></a>simulation |  The simulation target (`nvc_vhdl_run`) to execute.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
 | <a id="produce_waveform-use_fst"></a>use_fst |  A boolean indicating whether to expect an FST file instead of VCD file. Defaults to `False`.   | Boolean | optional |  `False`  |
 
 
-<a id="verilog_library"></a>
+<a id="nvc_vhdl_test"></a>
 
-## verilog_library
-
-<pre>
-load("@rules_nvc//build/nvc:rules.bzl", "verilog_library")
-
-verilog_library(<a href="#verilog_library-name">name</a>, <a href="#verilog_library-deps">deps</a>, <a href="#verilog_library-srcs">srcs</a>, <a href="#verilog_library-hdrs">hdrs</a>, <a href="#verilog_library-entities">entities</a>, <a href="#verilog_library-includes">includes</a>, <a href="#verilog_library-library_name">library_name</a>, <a href="#verilog_library-standard">standard</a>)
-</pre>
-
-Compiles Verilog source files into a library using NVC.
-
-**ATTRIBUTES**
-
-
-| Name  | Description | Type | Mandatory | Default |
-| :------------- | :------------- | :------------- | :------------- | :------------- |
-| <a id="verilog_library-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
-| <a id="verilog_library-deps"></a>deps |  List of dependency libraries.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
-| <a id="verilog_library-srcs"></a>srcs |  List of Verilog source files.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
-| <a id="verilog_library-hdrs"></a>hdrs |  List of Verilog header files.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
-| <a id="verilog_library-entities"></a>entities |  List of entities provided by this library.   | List of strings | optional |  `[]`  |
-| <a id="verilog_library-includes"></a>includes |  list of verilog include directories   | List of strings | optional |  `[]`  |
-| <a id="verilog_library-library_name"></a>library_name |  If the target name is not appropriate as a library name, provide one here   | String | optional |  `""`  |
-| <a id="verilog_library-standard"></a>standard |  The VHDL standard to use for compilation.   | String | optional |  `"2019"`  |
-
-
-<a id="vhdl_elaborate"></a>
-
-## vhdl_elaborate
+## nvc_vhdl_test
 
 <pre>
-load("@rules_nvc//build/nvc:rules.bzl", "vhdl_elaborate")
+load("@rules_nvc//build/nvc:rules.bzl", "nvc_vhdl_test")
 
-vhdl_elaborate(<a href="#vhdl_elaborate-name">name</a>, <a href="#vhdl_elaborate-library">library</a>, <a href="#vhdl_elaborate-standard">standard</a>)
-</pre>
-
-Elaborates a VHDL design using NVC.
-
-**ATTRIBUTES**
-
-
-| Name  | Description | Type | Mandatory | Default |
-| :------------- | :------------- | :------------- | :------------- | :------------- |
-| <a id="vhdl_elaborate-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
-| <a id="vhdl_elaborate-library"></a>library |  The `vhdl_library` target to elaborate.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
-| <a id="vhdl_elaborate-standard"></a>standard |  The VHDL standard to use for elaboration (e.g., '2019').   | String | optional |  `"2019"`  |
-
-
-<a id="vhdl_library"></a>
-
-## vhdl_library
-
-<pre>
-load("@rules_nvc//build/nvc:rules.bzl", "vhdl_library")
-
-vhdl_library(<a href="#vhdl_library-name">name</a>, <a href="#vhdl_library-deps">deps</a>, <a href="#vhdl_library-srcs">srcs</a>, <a href="#vhdl_library-entities">entities</a>, <a href="#vhdl_library-library_name">library_name</a>, <a href="#vhdl_library-standard">standard</a>, <a href="#vhdl_library-vpi_plugins">vpi_plugins</a>)
-</pre>
-
-Compiles VHDL source files into a library using NVC.
-
-**ATTRIBUTES**
-
-
-| Name  | Description | Type | Mandatory | Default |
-| :------------- | :------------- | :------------- | :------------- | :------------- |
-| <a id="vhdl_library-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
-| <a id="vhdl_library-deps"></a>deps |  A list of other `vhdl_library` targets that this library depends on.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
-| <a id="vhdl_library-srcs"></a>srcs |  A list of VHDL source files.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
-| <a id="vhdl_library-entities"></a>entities |  A list of VHDL entities provided by this library.   | List of strings | optional |  `[]`  |
-| <a id="vhdl_library-library_name"></a>library_name |  If the target name is not appropriate as a library name, provide one here   | String | optional |  `""`  |
-| <a id="vhdl_library-standard"></a>standard |  The VHDL standard to use for compilation (e.g., '2008', '2019'). Defaults to '2019'.   | String | optional |  `"2019"`  |
-| <a id="vhdl_library-vpi_plugins"></a>vpi_plugins |  List of VPI plugins required for simulation.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
-
-
-<a id="vhdl_run"></a>
-
-## vhdl_run
-
-<pre>
-load("@rules_nvc//build/nvc:rules.bzl", "vhdl_run")
-
-vhdl_run(<a href="#vhdl_run-name">name</a>, <a href="#vhdl_run-deps">deps</a>, <a href="#vhdl_run-args">args</a>, <a href="#vhdl_run-entity">entity</a>, <a href="#vhdl_run-standard">standard</a>, <a href="#vhdl_run-use_fst">use_fst</a>, <a href="#vhdl_run-use_vcd">use_vcd</a>)
-</pre>
-
-Simulates an elaborated VHDL design using NVC.
-
-**ATTRIBUTES**
-
-
-| Name  | Description | Type | Mandatory | Default |
-| :------------- | :------------- | :------------- | :------------- | :------------- |
-| <a id="vhdl_run-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
-| <a id="vhdl_run-deps"></a>deps |  A list of other `vhdl_library` targets that this simulation depends on.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
-| <a id="vhdl_run-args"></a>args |  A list of added command line args to use   | List of strings | optional |  `[]`  |
-| <a id="vhdl_run-entity"></a>entity |  The elaborated VHDL entity to simulate. This should be a `vhdl_elaborate` target.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
-| <a id="vhdl_run-standard"></a>standard |  The VHDL standard to use for simulation. Defaults to '2019'.   | String | optional |  `"2019"`  |
-| <a id="vhdl_run-use_fst"></a>use_fst |  A boolean indicating whether to generate a FST file for waveform viewing. Defaults to `False`. Takes precedence over `use_vcd`.   | Boolean | optional |  `False`  |
-| <a id="vhdl_run-use_vcd"></a>use_vcd |  A boolean indicating whether to generate a VCD (Value Change Dump) file for waveform viewing. Defaults to `True`.   | Boolean | optional |  `True`  |
-
-
-<a id="vhdl_test"></a>
-
-## vhdl_test
-
-<pre>
-load("@rules_nvc//build/nvc:rules.bzl", "vhdl_test")
-
-vhdl_test(<a href="#vhdl_test-name">name</a>, <a href="#vhdl_test-srcs">srcs</a>, <a href="#vhdl_test-deps">deps</a>, <a href="#vhdl_test-standard">standard</a>, <a href="#vhdl_test-args">args</a>, <a href="#vhdl_test-entity">entity</a>, <a href="#vhdl_test-entities">entities</a>)
+nvc_vhdl_test(<a href="#nvc_vhdl_test-name">name</a>, <a href="#nvc_vhdl_test-srcs">srcs</a>, <a href="#nvc_vhdl_test-deps">deps</a>, <a href="#nvc_vhdl_test-standard">standard</a>, <a href="#nvc_vhdl_test-args">args</a>, <a href="#nvc_vhdl_test-entity">entity</a>, <a href="#nvc_vhdl_test-entities">entities</a>)
 </pre>
 
 Defines a VHDL test.
 
-This macro combines `vhdl_library`, `vhdl_elaborate`, and internal test
+This macro combines `nvc_vhdl_library`, `nvc_vhdl_elaborate`, and internal test
 execution steps into a single logical target.
 
 
@@ -221,13 +221,13 @@ execution steps into a single logical target.
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
-| <a id="vhdl_test-name"></a>name |  The name of the base test target.   |  none |
-| <a id="vhdl_test-srcs"></a>srcs |  A list of VHDL source files (`.vhdl` or `.vhd`).   |  none |
-| <a id="vhdl_test-deps"></a>deps |  A list of `vhdl_library` targets that this test depends on.   |  none |
-| <a id="vhdl_test-standard"></a>standard |  The VHDL standard to use (e.g., "2008", "2019"). Defaults to "2019".   |  `"2019"` |
-| <a id="vhdl_test-args"></a>args |  A list of additional command-line arguments to pass to the NVC simulator.   |  `[]` |
-| <a id="vhdl_test-entity"></a>entity |  A single entity to test.   |  `None` |
-| <a id="vhdl_test-entities"></a>entities |  A list of entities to test. If both `entity` and `entities` are provided, all are tested.   |  `[]` |
+| <a id="nvc_vhdl_test-name"></a>name |  The name of the base test target.   |  none |
+| <a id="nvc_vhdl_test-srcs"></a>srcs |  A list of VHDL source files (`.vhdl` or `.vhd`).   |  none |
+| <a id="nvc_vhdl_test-deps"></a>deps |  A list of `nvc_vhdl_library` targets that this test depends on.   |  none |
+| <a id="nvc_vhdl_test-standard"></a>standard |  The VHDL standard to use (e.g., "2008", "2019"). Defaults to "2019".   |  `"2019"` |
+| <a id="nvc_vhdl_test-args"></a>args |  A list of additional command-line arguments to pass to the NVC simulator.   |  `[]` |
+| <a id="nvc_vhdl_test-entity"></a>entity |  A single entity to test.   |  `None` |
+| <a id="nvc_vhdl_test-entities"></a>entities |  A list of entities to test. If both `entity` and `entities` are provided, all are tested.   |  `[]` |
 
 
 <a id="wave_view"></a>
@@ -237,7 +237,7 @@ execution steps into a single logical target.
 <pre>
 load("@rules_nvc//build/nvc:rules.bzl", "wave_view")
 
-wave_view(<a href="#wave_view-name">name</a>, <a href="#wave_view-vhdl_run">vhdl_run</a>, <a href="#wave_view-args">args</a>, <a href="#wave_view-deps">deps</a>, <a href="#wave_view-viewer">viewer</a>, <a href="#wave_view-testonly">testonly</a>, <a href="#wave_view-save_file">save_file</a>)
+wave_view(<a href="#wave_view-name">name</a>, <a href="#wave_view-nvc_vhdl_run">nvc_vhdl_run</a>, <a href="#wave_view-args">args</a>, <a href="#wave_view-deps">deps</a>, <a href="#wave_view-viewer">viewer</a>, <a href="#wave_view-testonly">testonly</a>, <a href="#wave_view-save_file">save_file</a>)
 </pre>
 
 Generates a sh_binary viewer.
@@ -245,7 +245,7 @@ Generates a sh_binary viewer.
 # Args
 
 - name: the target name.
-- vhdl_run: the target name for the `vhdl_run` target to
+- nvc_vhdl_run: the target name for the `nvc_vhdl_run` target to
   use the output from.
 - args: any additional arguments to add to invoke the viewer.
 - viewer: the viewer to invoke. The viewer must be compatible
@@ -258,7 +258,7 @@ Generates a sh_binary viewer.
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
 | <a id="wave_view-name"></a>name |  <p align="center"> - </p>   |  none |
-| <a id="wave_view-vhdl_run"></a>vhdl_run |  <p align="center"> - </p>   |  none |
+| <a id="wave_view-nvc_vhdl_run"></a>nvc_vhdl_run |  <p align="center"> - </p>   |  none |
 | <a id="wave_view-args"></a>args |  <p align="center"> - </p>   |  `[]` |
 | <a id="wave_view-deps"></a>deps |  <p align="center"> - </p>   |  `[]` |
 | <a id="wave_view-viewer"></a>viewer |  <p align="center"> - </p>   |  `"gtkwave"` |

--- a/build/tests/nvc-toolchain/basic/BUILD.bazel
+++ b/build/tests/nvc-toolchain/basic/BUILD.bazel
@@ -1,11 +1,11 @@
 load(
     "//build/nvc:rules.bzl",
-    "vhdl_elaborate",
-    "vhdl_library",
-    "vhdl_run",
+    "nvc_vhdl_elaborate",
+    "nvc_vhdl_library",
+    "nvc_vhdl_run",
 )
 
-vhdl_library(
+nvc_vhdl_library(
     name = "work",
     srcs = [
         "test.vhdl",
@@ -13,12 +13,12 @@ vhdl_library(
     entities = ["hello_world"],
 )
 
-vhdl_elaborate(
+nvc_vhdl_elaborate(
     name = "hello_world",
     library = ":work",
 )
 
-vhdl_run(
+nvc_vhdl_run(
     name = "sim",
     entity = ":hello_world",
 )

--- a/build/tests/nvc-toolchain/sim/BUILD.bazel
+++ b/build/tests/nvc-toolchain/sim/BUILD.bazel
@@ -1,6 +1,6 @@
-load("//build/nvc:rules.bzl", "vhdl_elaborate", "vhdl_library", "vhdl_run")
+load("//build/nvc:rules.bzl", "nvc_vhdl_elaborate", "nvc_vhdl_library", "nvc_vhdl_run")
 
-vhdl_library(
+nvc_vhdl_library(
     name = "sim",
     srcs = [
         "clkgen.vhdl",
@@ -8,7 +8,7 @@ vhdl_library(
     ],
 )
 
-vhdl_library(
+nvc_vhdl_library(
     name = "test",
     srcs = [
         "clkgen_test.vhdl",
@@ -16,12 +16,12 @@ vhdl_library(
     deps = [":sim"],
 )
 
-vhdl_elaborate(
+nvc_vhdl_elaborate(
     name = "tb",
     library = ":test",
 )
 
-vhdl_run(
+nvc_vhdl_run(
     name = "run",
     entity = ":tb",
 )

--- a/build/tests/nvc-toolchain/two_libraries/BUILD.bazel
+++ b/build/tests/nvc-toolchain/two_libraries/BUILD.bazel
@@ -1,11 +1,11 @@
 load(
     "//build/nvc:rules.bzl",
-    "vhdl_elaborate",
-    "vhdl_library",
-    "vhdl_run",
+    "nvc_vhdl_elaborate",
+    "nvc_vhdl_library",
+    "nvc_vhdl_run",
 )
 
-vhdl_library(
+nvc_vhdl_library(
     name = "work",
     srcs = [
         "test.vhdl",
@@ -14,17 +14,17 @@ vhdl_library(
     deps = [":pkg"],
 )
 
-vhdl_elaborate(
+nvc_vhdl_elaborate(
     name = "hello_world",
     library = ":work",
 )
 
-vhdl_run(
+nvc_vhdl_run(
     name = "sim",
     entity = ":hello_world",
 )
 
-vhdl_library(
+nvc_vhdl_library(
     name = "pkg",
     srcs = [
         "package.vhdl",

--- a/integration/MODULE.bazel.lock
+++ b/integration/MODULE.bazel.lock
@@ -295,6 +295,8 @@
     "https://bcr.bazel.build/modules/rules_verilog/1.1.0/MODULE.bazel": "7b1d2d0321566572b61b76a4b4c263ce4da27ee0437552e1c70cff838101db57",
     "https://bcr.bazel.build/modules/rules_verilog/1.1.1/MODULE.bazel": "adcccf08f92e16936d6aa2e872f31a79e80712333be604de750d4b109fae1519",
     "https://bcr.bazel.build/modules/rules_verilog/1.1.1/source.json": "32a02fe6f97e1a233cff48e0eae70243e2e25d4c57fc684f933e06ef67440d8b",
+    "https://bcr.bazel.build/modules/rules_vhdl/0.1.2/MODULE.bazel": "03410b3c95f5832339a8a9f737d1a07bd57dd411d965425fb3bec4fdc4dd107f",
+    "https://bcr.bazel.build/modules/rules_vhdl/0.1.2/source.json": "2427af347389f8867f4d6a358a96233226a9077f6502945f4e2f8a70d7f69aab",
     "https://bcr.bazel.build/modules/stardoc/0.5.1/MODULE.bazel": "1a05d92974d0c122f5ccf09291442580317cdd859f07a8655f1db9a60374f9f8",
     "https://bcr.bazel.build/modules/stardoc/0.5.3/MODULE.bazel": "c7f6948dae6999bf0db32c1858ae345f112cacf98f174c7a8bb707e41b974f1c",
     "https://bcr.bazel.build/modules/stardoc/0.6.2/MODULE.bazel": "7060193196395f5dd668eda046ccbeacebfd98efc77fed418dbe2b82ffaa39fd",
@@ -574,6 +576,7 @@
     "https://raw.githubusercontent.com/filmil/bazel-registry/main/modules/rules_verilator/1.0.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/filmil/bazel-registry/main/modules/rules_verilog/1.1.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/filmil/bazel-registry/main/modules/rules_verilog/1.1.1/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/filmil/bazel-registry/main/modules/rules_vhdl/0.1.2/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/filmil/bazel-registry/main/modules/stardoc/0.5.1/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/filmil/bazel-registry/main/modules/stardoc/0.5.3/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/filmil/bazel-registry/main/modules/stardoc/0.6.2/MODULE.bazel": "not found",
@@ -595,6 +598,703 @@
     "https://raw.githubusercontent.com/filmil/bazel-registry/main/modules/zlib/1.3.1/MODULE.bazel": "not found"
   },
   "selectedYankedVersions": {},
-  "moduleExtensions": {},
-  "facts": {}
+  "moduleExtensions": {
+    "@@rules_android+//rules/android_sdk_repository:rule.bzl%android_sdk_repository_extension": {
+      "general": {
+        "bzlTransitiveDigest": "qHbR00gVzVzkxX+PRtv4UGcUFMtBz7TK9CNYUWH8nIE=",
+        "usagesDigest": "tTIw/WMyb1t/LzacDY8lDjUznzxQ3MyXW6474WIS3WQ=",
+        "recordedInputs": [],
+        "generatedRepoSpecs": {
+          "androidsdk": {
+            "repoRuleId": "@@rules_android+//rules/android_sdk_repository:rule.bzl%_android_sdk_repository",
+            "attributes": {}
+          }
+        }
+      }
+    },
+    "@@rules_python+//python/extensions:config.bzl%config": {
+      "general": {
+        "bzlTransitiveDigest": "2hLgIvNVTLgxus0ZuXtleBe70intCfo0cHs8qvt6cdM=",
+        "usagesDigest": "ZVSXMAGpD+xzVNPuvF1IoLBkty7TROO0+akMapt1pAg=",
+        "recordedInputs": [
+          "REPO_MAPPING:rules_python+,bazel_tools bazel_tools",
+          "REPO_MAPPING:rules_python+,pypi__build rules_python++config+pypi__build",
+          "REPO_MAPPING:rules_python+,pypi__click rules_python++config+pypi__click",
+          "REPO_MAPPING:rules_python+,pypi__colorama rules_python++config+pypi__colorama",
+          "REPO_MAPPING:rules_python+,pypi__importlib_metadata rules_python++config+pypi__importlib_metadata",
+          "REPO_MAPPING:rules_python+,pypi__installer rules_python++config+pypi__installer",
+          "REPO_MAPPING:rules_python+,pypi__more_itertools rules_python++config+pypi__more_itertools",
+          "REPO_MAPPING:rules_python+,pypi__packaging rules_python++config+pypi__packaging",
+          "REPO_MAPPING:rules_python+,pypi__pep517 rules_python++config+pypi__pep517",
+          "REPO_MAPPING:rules_python+,pypi__pip rules_python++config+pypi__pip",
+          "REPO_MAPPING:rules_python+,pypi__pip_tools rules_python++config+pypi__pip_tools",
+          "REPO_MAPPING:rules_python+,pypi__pyproject_hooks rules_python++config+pypi__pyproject_hooks",
+          "REPO_MAPPING:rules_python+,pypi__setuptools rules_python++config+pypi__setuptools",
+          "REPO_MAPPING:rules_python+,pypi__tomli rules_python++config+pypi__tomli",
+          "REPO_MAPPING:rules_python+,pypi__wheel rules_python++config+pypi__wheel",
+          "REPO_MAPPING:rules_python+,pypi__zipp rules_python++config+pypi__zipp"
+        ],
+        "generatedRepoSpecs": {
+          "rules_python_internal": {
+            "repoRuleId": "@@rules_python+//python/private:internal_config_repo.bzl%internal_config_repo",
+            "attributes": {
+              "transition_setting_generators": {},
+              "transition_settings": []
+            }
+          },
+          "pypi__build": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://files.pythonhosted.org/packages/e2/03/f3c8ba0a6b6e30d7d18c40faab90807c9bb5e9a1e3b2fe2008af624a9c97/build-1.2.1-py3-none-any.whl",
+              "sha256": "75e10f767a433d9a86e50d83f418e83efc18ede923ee5ff7df93b6cb0306c5d4",
+              "type": "zip",
+              "build_file_content": "package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:py_library.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude to avoid non-determinism.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"
+            }
+          },
+          "pypi__click": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://files.pythonhosted.org/packages/00/2e/d53fa4befbf2cfa713304affc7ca780ce4fc1fd8710527771b58311a3229/click-8.1.7-py3-none-any.whl",
+              "sha256": "ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28",
+              "type": "zip",
+              "build_file_content": "package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:py_library.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude to avoid non-determinism.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"
+            }
+          },
+          "pypi__colorama": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl",
+              "sha256": "4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6",
+              "type": "zip",
+              "build_file_content": "package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:py_library.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude to avoid non-determinism.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"
+            }
+          },
+          "pypi__importlib_metadata": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://files.pythonhosted.org/packages/2d/0a/679461c511447ffaf176567d5c496d1de27cbe34a87df6677d7171b2fbd4/importlib_metadata-7.1.0-py3-none-any.whl",
+              "sha256": "30962b96c0c223483ed6cc7280e7f0199feb01a0e40cfae4d4450fc6fab1f570",
+              "type": "zip",
+              "build_file_content": "package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:py_library.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude to avoid non-determinism.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"
+            }
+          },
+          "pypi__installer": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://files.pythonhosted.org/packages/e5/ca/1172b6638d52f2d6caa2dd262ec4c811ba59eee96d54a7701930726bce18/installer-0.7.0-py3-none-any.whl",
+              "sha256": "05d1933f0a5ba7d8d6296bb6d5018e7c94fa473ceb10cf198a92ccea19c27b53",
+              "type": "zip",
+              "build_file_content": "package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:py_library.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude to avoid non-determinism.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"
+            }
+          },
+          "pypi__more_itertools": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://files.pythonhosted.org/packages/50/e2/8e10e465ee3987bb7c9ab69efb91d867d93959095f4807db102d07995d94/more_itertools-10.2.0-py3-none-any.whl",
+              "sha256": "686b06abe565edfab151cb8fd385a05651e1fdf8f0a14191e4439283421f8684",
+              "type": "zip",
+              "build_file_content": "package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:py_library.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude to avoid non-determinism.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"
+            }
+          },
+          "pypi__packaging": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://files.pythonhosted.org/packages/49/df/1fceb2f8900f8639e278b056416d49134fb8d84c5942ffaa01ad34782422/packaging-24.0-py3-none-any.whl",
+              "sha256": "2ddfb553fdf02fb784c234c7ba6ccc288296ceabec964ad2eae3777778130bc5",
+              "type": "zip",
+              "build_file_content": "package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:py_library.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude to avoid non-determinism.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"
+            }
+          },
+          "pypi__pep517": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://files.pythonhosted.org/packages/25/6e/ca4a5434eb0e502210f591b97537d322546e4833dcb4d470a48c375c5540/pep517-0.13.1-py3-none-any.whl",
+              "sha256": "31b206f67165b3536dd577c5c3f1518e8fbaf38cbc57efff8369a392feff1721",
+              "type": "zip",
+              "build_file_content": "package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:py_library.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude to avoid non-determinism.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"
+            }
+          },
+          "pypi__pip": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://files.pythonhosted.org/packages/8a/6a/19e9fe04fca059ccf770861c7d5721ab4c2aebc539889e97c7977528a53b/pip-24.0-py3-none-any.whl",
+              "sha256": "ba0d021a166865d2265246961bec0152ff124de910c5cc39f1156ce3fa7c69dc",
+              "type": "zip",
+              "build_file_content": "package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:py_library.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude to avoid non-determinism.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"
+            }
+          },
+          "pypi__pip_tools": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://files.pythonhosted.org/packages/0d/dc/38f4ce065e92c66f058ea7a368a9c5de4e702272b479c0992059f7693941/pip_tools-7.4.1-py3-none-any.whl",
+              "sha256": "4c690e5fbae2f21e87843e89c26191f0d9454f362d8acdbd695716493ec8b3a9",
+              "type": "zip",
+              "build_file_content": "package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:py_library.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude to avoid non-determinism.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"
+            }
+          },
+          "pypi__pyproject_hooks": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://files.pythonhosted.org/packages/ae/f3/431b9d5fe7d14af7a32340792ef43b8a714e7726f1d7b69cc4e8e7a3f1d7/pyproject_hooks-1.1.0-py3-none-any.whl",
+              "sha256": "7ceeefe9aec63a1064c18d939bdc3adf2d8aa1988a510afec15151578b232aa2",
+              "type": "zip",
+              "build_file_content": "package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:py_library.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude to avoid non-determinism.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"
+            }
+          },
+          "pypi__setuptools": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://files.pythonhosted.org/packages/90/99/158ad0609729111163fc1f674a5a42f2605371a4cf036d0441070e2f7455/setuptools-78.1.1-py3-none-any.whl",
+              "sha256": "c3a9c4211ff4c309edb8b8c4f1cbfa7ae324c4ba9f91ff254e3d305b9fd54561",
+              "type": "zip",
+              "build_file_content": "package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:py_library.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude to avoid non-determinism.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"
+            }
+          },
+          "pypi__tomli": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://files.pythonhosted.org/packages/97/75/10a9ebee3fd790d20926a90a2547f0bf78f371b2f13aa822c759680ca7b9/tomli-2.0.1-py3-none-any.whl",
+              "sha256": "939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
+              "type": "zip",
+              "build_file_content": "package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:py_library.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude to avoid non-determinism.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"
+            }
+          },
+          "pypi__wheel": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://files.pythonhosted.org/packages/7d/cd/d7460c9a869b16c3dd4e1e403cce337df165368c71d6af229a74699622ce/wheel-0.43.0-py3-none-any.whl",
+              "sha256": "55c570405f142630c6b9f72fe09d9b67cf1477fcf543ae5b8dcb1f5b7377da81",
+              "type": "zip",
+              "build_file_content": "package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:py_library.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude to avoid non-determinism.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"
+            }
+          },
+          "pypi__zipp": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://files.pythonhosted.org/packages/da/55/a03fd7240714916507e1fcf7ae355bd9d9ed2e6db492595f1a67f61681be/zipp-3.18.2-py3-none-any.whl",
+              "sha256": "dce197b859eb796242b0622af1b8beb0a722d52aa2f57133ead08edd5bf5374e",
+              "type": "zip",
+              "build_file_content": "package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:py_library.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude to avoid non-determinism.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"
+            }
+          }
+        }
+      }
+    },
+    "@@rules_python+//python/uv:uv.bzl%uv": {
+      "general": {
+        "bzlTransitiveDigest": "ijW9KS7qsIY+yBVvJ+Nr1mzwQox09j13DnE3iIwaeTM=",
+        "usagesDigest": "H8dQoNZcoqP+Mu0tHZTi4KHATzvNkM5ePuEqoQdklIU=",
+        "recordedInputs": [
+          "REPO_MAPPING:rules_python+,bazel_tools bazel_tools",
+          "REPO_MAPPING:rules_python+,platforms platforms"
+        ],
+        "generatedRepoSpecs": {
+          "uv": {
+            "repoRuleId": "@@rules_python+//python/uv/private:uv_toolchains_repo.bzl%uv_toolchains_repo",
+            "attributes": {
+              "toolchain_type": "'@@rules_python+//python/uv:uv_toolchain_type'",
+              "toolchain_names": [
+                "none"
+              ],
+              "toolchain_implementations": {
+                "none": "'@@rules_python+//python:none'"
+              },
+              "toolchain_compatible_with": {
+                "none": [
+                  "@platforms//:incompatible"
+                ]
+              },
+              "toolchain_target_settings": {}
+            }
+          }
+        }
+      }
+    }
+  },
+  "facts": {
+    "@@rules_go+//go:extensions.bzl%go_sdk": {
+      "1.22.4": {
+        "aix_ppc64": [
+          "go1.22.4.aix-ppc64.tar.gz",
+          "b9647fa9fc83a0cc5d4f092a19eaeaecf45f063a5aa7d4962fde65aeb7ae6ce1"
+        ],
+        "darwin_amd64": [
+          "go1.22.4.darwin-amd64.tar.gz",
+          "c95967f50aa4ace34af0c236cbdb49a9a3e80ee2ad09d85775cb4462a5c19ed3"
+        ],
+        "darwin_arm64": [
+          "go1.22.4.darwin-arm64.tar.gz",
+          "242b78dc4c8f3d5435d28a0d2cec9b4c1aa999b601fb8aa59fb4e5a1364bf827"
+        ],
+        "dragonfly_amd64": [
+          "go1.22.4.dragonfly-amd64.tar.gz",
+          "f2fbb51af4719d3616efb482d6ed2b96579b474156f85a7ddc6f126764feec4b"
+        ],
+        "freebsd_386": [
+          "go1.22.4.freebsd-386.tar.gz",
+          "7c54884bb9f274884651d41e61d1bc12738863ad1497e97ea19ad0e9aa6bf7b5"
+        ],
+        "freebsd_amd64": [
+          "go1.22.4.freebsd-amd64.tar.gz",
+          "88d44500e1701dd35797619774d6dd51bf60f45a8338b0a82ddc018e4e63fb78"
+        ],
+        "freebsd_arm64": [
+          "go1.22.4.freebsd-arm64.tar.gz",
+          "726dc093cf020277be45debf03c3b02b43c2efb3e2a5d4fba8f52579d65327dc"
+        ],
+        "freebsd_armv6l": [
+          "go1.22.4.freebsd-arm.tar.gz",
+          "3d9efe47db142a22679aba46b1772e3900b0d87ae13bd2b3bc80dbf2ac0b2cd6"
+        ],
+        "freebsd_riscv64": [
+          "go1.22.4.freebsd-riscv64.tar.gz",
+          "5f6b67e5e32f1d6ccb2d4dcb44934a5e2e870a877ba7443d86ec43cfc28afa71"
+        ],
+        "illumos_amd64": [
+          "go1.22.4.illumos-amd64.tar.gz",
+          "d56ecc2f85b6418a21ef83879594d0c42ab4f65391a676bb12254870e6690d63"
+        ],
+        "linux_386": [
+          "go1.22.4.linux-386.tar.gz",
+          "47a2a8d249a91eb8605c33bceec63aedda0441a43eac47b4721e3975ff916cec"
+        ],
+        "linux_amd64": [
+          "go1.22.4.linux-amd64.tar.gz",
+          "ba79d4526102575196273416239cca418a651e049c2b099f3159db85e7bade7d"
+        ],
+        "linux_arm64": [
+          "go1.22.4.linux-arm64.tar.gz",
+          "a8e177c354d2e4a1b61020aca3562e27ea3e8f8247eca3170e3fa1e0c2f9e771"
+        ],
+        "linux_armv6l": [
+          "go1.22.4.linux-armv6l.tar.gz",
+          "e2b143fbacbc9cbd448e9ef41ac3981f0488ce849af1cf37e2341d09670661de"
+        ],
+        "linux_loong64": [
+          "go1.22.4.linux-loong64.tar.gz",
+          "e2ff9436e4b34bf6926b06d97916e26d67a909a2effec17967245900f0816f1d"
+        ],
+        "linux_mips": [
+          "go1.22.4.linux-mips.tar.gz",
+          "73f0dcc60458c4770593b05a7bc01cc0d31fc98f948c0c2334812c7a1f2fc3f1"
+        ],
+        "linux_mips64": [
+          "go1.22.4.linux-mips64.tar.gz",
+          "417af97fc2630a647052375768be4c38adcc5af946352ea5b28613ea81ca5d45"
+        ],
+        "linux_mips64le": [
+          "go1.22.4.linux-mips64le.tar.gz",
+          "7486e2d7dd8c98eb44df815ace35a7fe7f30b7c02326e3741bd934077508139b"
+        ],
+        "linux_mipsle": [
+          "go1.22.4.linux-mipsle.tar.gz",
+          "69479c8aad301e459a8365b40cad1074a0dbba5defb9291669f94809c4c4be6e"
+        ],
+        "linux_ppc64": [
+          "go1.22.4.linux-ppc64.tar.gz",
+          "dd238847e65bc3e2745caca475a5db6522a2fcf85cf6c38fc36a06642b19efd7"
+        ],
+        "linux_ppc64le": [
+          "go1.22.4.linux-ppc64le.tar.gz",
+          "a3e5834657ef92523f570f798fed42f1f87bc18222a16815ec76b84169649ec4"
+        ],
+        "linux_riscv64": [
+          "go1.22.4.linux-riscv64.tar.gz",
+          "56a827ff7dc6245bcd7a1e9288dffaa1d8b0fd7468562264c1523daf3b4f1b4a"
+        ],
+        "linux_s390x": [
+          "go1.22.4.linux-s390x.tar.gz",
+          "7590c3e278e2dc6040aae0a39da3ca1eb2e3921673a7304cc34d588c45889eec"
+        ],
+        "netbsd_386": [
+          "go1.22.4.netbsd-386.tar.gz",
+          "ddd2eebe34471a2502de6c5dad04ab27c9fc80cbde7a9ad5b3c66ecec4504e1d"
+        ],
+        "netbsd_amd64": [
+          "go1.22.4.netbsd-amd64.tar.gz",
+          "33af79f6f935f6fbacc5d23876450b3567b79348fc065beef8e64081127dd234"
+        ],
+        "netbsd_arm64": [
+          "go1.22.4.netbsd-arm64.tar.gz",
+          "c9a2971dec9f6d320c6f2b049b2353c6d0a2d35e87b8a4b2d78a2f0d62545f8e"
+        ],
+        "netbsd_armv6l": [
+          "go1.22.4.netbsd-arm.tar.gz",
+          "fa3550ebd5375a70b3bcd342b5a71f4bd271dcbbfaf4eabefa2144ab5d8924b6"
+        ],
+        "openbsd_386": [
+          "go1.22.4.openbsd-386.tar.gz",
+          "d21af022331bfdc2b5b161d616c3a1a4573d33cf7a30416ee509a8f3641deb47"
+        ],
+        "openbsd_amd64": [
+          "go1.22.4.openbsd-amd64.tar.gz",
+          "72c0094c43f7e5722ec49c2a3e9dfa7a1123ac43a5f3a63eecf3e3795d3ff0ae"
+        ],
+        "openbsd_arm64": [
+          "go1.22.4.openbsd-arm64.tar.gz",
+          "a7ab8d4e0b02bf06ed144ba42c61c0e93ee00f2b433415dfd4ad4b6e79f31650"
+        ],
+        "openbsd_armv6l": [
+          "go1.22.4.openbsd-arm.tar.gz",
+          "1096831ea3c5ea3ca57d14251d9eda3786889531eb40d7d6775dcaa324d4b065"
+        ],
+        "openbsd_ppc64": [
+          "go1.22.4.openbsd-ppc64.tar.gz",
+          "9716327c8a628358798898dc5148c49dbbeb5196bf2cbf088e550721a6e4f60b"
+        ],
+        "plan9_386": [
+          "go1.22.4.plan9-386.tar.gz",
+          "a8dd4503c95c32a502a616ab78870a19889c9325fe9bd31eb16dd69346e4bfa8"
+        ],
+        "plan9_amd64": [
+          "go1.22.4.plan9-amd64.tar.gz",
+          "5423a25808d76fe5aca8607a2e5ac5673abf45446b168cb5e9d8519ee9fe39a1"
+        ],
+        "plan9_armv6l": [
+          "go1.22.4.plan9-arm.tar.gz",
+          "6af939ad583f5c85c09c53728ab7d38c3cc2b39167562d6c18a07c5c6608b370"
+        ],
+        "solaris_amd64": [
+          "go1.22.4.solaris-amd64.tar.gz",
+          "e8cabe69c03085725afdb32a6f9998191a3e55a747b270d835fd05000d56abba"
+        ],
+        "windows_386": [
+          "go1.22.4.windows-386.zip",
+          "aca4e2c37278a10f1c70dd0df142f7d66b50334fcee48978d409202d308d6d25"
+        ],
+        "windows_amd64": [
+          "go1.22.4.windows-amd64.zip",
+          "26321c4d945a0035d8a5bc4a1965b0df401ff8ceac66ce2daadabf9030419a98"
+        ],
+        "windows_arm64": [
+          "go1.22.4.windows-arm64.zip",
+          "8a2daa9ea28cbdafddc6171aefed384f4e5b6e714fb52116fe9ed25a132f37ed"
+        ],
+        "windows_armv6l": [
+          "go1.22.4.windows-arm.zip",
+          "5fcd0671a49cecf39b41021621ee1b6e7aa1370f37122b72e80d4fd4185833b6"
+        ]
+      },
+      "1.25.0": {
+        "aix_ppc64": [
+          "go1.25.0.aix-ppc64.tar.gz",
+          "e5234a7dac67bc86c528fe9752fc9d63557918627707a733ab4cac1a6faed2d4"
+        ],
+        "darwin_amd64": [
+          "go1.25.0.darwin-amd64.tar.gz",
+          "5bd60e823037062c2307c71e8111809865116714d6f6b410597cf5075dfd80ef"
+        ],
+        "darwin_arm64": [
+          "go1.25.0.darwin-arm64.tar.gz",
+          "544932844156d8172f7a28f77f2ac9c15a23046698b6243f633b0a0b00c0749c"
+        ],
+        "dragonfly_amd64": [
+          "go1.25.0.dragonfly-amd64.tar.gz",
+          "5ed3cf9a810a1483822538674f1336c06b51aa1b94d6d545a1a0319a48177120"
+        ],
+        "freebsd_386": [
+          "go1.25.0.freebsd-386.tar.gz",
+          "abea5d5c6697e6b5c224731f2158fe87c602996a2a233ac0c4730cd57bf8374e"
+        ],
+        "freebsd_amd64": [
+          "go1.25.0.freebsd-amd64.tar.gz",
+          "86e6fe0a29698d7601c4442052dac48bd58d532c51cccb8f1917df648138730b"
+        ],
+        "freebsd_arm": [
+          "go1.25.0.freebsd-arm.tar.gz",
+          "d90b78e41921f72f30e8bbc81d9dec2cff7ff384a33d8d8debb24053e4336bfe"
+        ],
+        "freebsd_arm64": [
+          "go1.25.0.freebsd-arm64.tar.gz",
+          "451d0da1affd886bfb291b7c63a6018527b269505db21ce6e14724f22ab0662e"
+        ],
+        "freebsd_riscv64": [
+          "go1.25.0.freebsd-riscv64.tar.gz",
+          "7b565f76bd8bda46549eeaaefe0e53b251e644c230577290c0f66b1ecdb3cdbe"
+        ],
+        "illumos_amd64": [
+          "go1.25.0.illumos-amd64.tar.gz",
+          "b1e1fdaab1ad25aa1c08d7a36c97d45d74b98b89c3f78c6d2145f77face54a2c"
+        ],
+        "linux_386": [
+          "go1.25.0.linux-386.tar.gz",
+          "8c602dd9d99bc9453b3995d20ce4baf382cc50855900a0ece5de9929df4a993a"
+        ],
+        "linux_amd64": [
+          "go1.25.0.linux-amd64.tar.gz",
+          "2852af0cb20a13139b3448992e69b868e50ed0f8a1e5940ee1de9e19a123b613"
+        ],
+        "linux_arm64": [
+          "go1.25.0.linux-arm64.tar.gz",
+          "05de75d6994a2783699815ee553bd5a9327d8b79991de36e38b66862782f54ae"
+        ],
+        "linux_armv6l": [
+          "go1.25.0.linux-armv6l.tar.gz",
+          "a5a8f8198fcf00e1e485b8ecef9ee020778bf32a408a4e8873371bfce458cd09"
+        ],
+        "linux_loong64": [
+          "go1.25.0.linux-loong64.tar.gz",
+          "cab86b1cf761b1cb3bac86a8877cfc92e7b036fc0d3084123d77013d61432afc"
+        ],
+        "linux_mips": [
+          "go1.25.0.linux-mips.tar.gz",
+          "d66b6fb74c3d91b9829dc95ec10ca1f047ef5e89332152f92e136cf0e2da5be1"
+        ],
+        "linux_mips64": [
+          "go1.25.0.linux-mips64.tar.gz",
+          "4082e4381a8661bc2a839ff94ba3daf4f6cde20f8fb771b5b3d4762dc84198a2"
+        ],
+        "linux_mips64le": [
+          "go1.25.0.linux-mips64le.tar.gz",
+          "70002c299ec7f7175ac2ef673b1b347eecfa54ae11f34416a6053c17f855afcc"
+        ],
+        "linux_mipsle": [
+          "go1.25.0.linux-mipsle.tar.gz",
+          "b00a3a39eff099f6df9f1c7355bf28e4589d0586f42d7d4a394efb763d145a73"
+        ],
+        "linux_ppc64": [
+          "go1.25.0.linux-ppc64.tar.gz",
+          "df166f33bd98160662560a72ff0b4ba731f969a80f088922bddcf566a88c1ec1"
+        ],
+        "linux_ppc64le": [
+          "go1.25.0.linux-ppc64le.tar.gz",
+          "0f18a89e7576cf2c5fa0b487a1635d9bcbf843df5f110e9982c64df52a983ad0"
+        ],
+        "linux_riscv64": [
+          "go1.25.0.linux-riscv64.tar.gz",
+          "c018ff74a2c48d55c8ca9b07c8e24163558ffec8bea08b326d6336905d956b67"
+        ],
+        "linux_s390x": [
+          "go1.25.0.linux-s390x.tar.gz",
+          "34e5a2e19f2292fbaf8783e3a241e6e49689276aef6510a8060ea5ef54eee408"
+        ],
+        "netbsd_386": [
+          "go1.25.0.netbsd-386.tar.gz",
+          "f8586cdb7aa855657609a5c5f6dbf523efa00c2bbd7c76d3936bec80aa6c0aba"
+        ],
+        "netbsd_amd64": [
+          "go1.25.0.netbsd-amd64.tar.gz",
+          "ae8dc1469385b86a157a423bb56304ba45730de8a897615874f57dd096db2c2a"
+        ],
+        "netbsd_arm": [
+          "go1.25.0.netbsd-arm.tar.gz",
+          "1ff7e4cc764425fc9dd6825eaee79d02b3c7cafffbb3691687c8d672ade76cb7"
+        ],
+        "netbsd_arm64": [
+          "go1.25.0.netbsd-arm64.tar.gz",
+          "e1b310739f26724216aa6d7d7208c4031f9ff54c9b5b9a796ddc8bebcb4a5f16"
+        ],
+        "openbsd_386": [
+          "go1.25.0.openbsd-386.tar.gz",
+          "4802a9b20e533da91adb84aab42e94aa56cfe3e5475d0550bed3385b182e69d8"
+        ],
+        "openbsd_amd64": [
+          "go1.25.0.openbsd-amd64.tar.gz",
+          "c016cd984bebe317b19a4f297c4f50def120dc9788490540c89f28e42f1dabe1"
+        ],
+        "openbsd_arm": [
+          "go1.25.0.openbsd-arm.tar.gz",
+          "a1e31d0bf22172ddde42edf5ec811ef81be43433df0948ece52fecb247ccfd8d"
+        ],
+        "openbsd_arm64": [
+          "go1.25.0.openbsd-arm64.tar.gz",
+          "343ea8edd8c218196e15a859c6072d0dd3246fbbb168481ab665eb4c4140458d"
+        ],
+        "openbsd_ppc64": [
+          "go1.25.0.openbsd-ppc64.tar.gz",
+          "694c14da1bcaeb5e3332d49bdc2b6d155067648f8fe1540c5de8f3cf8e157154"
+        ],
+        "openbsd_riscv64": [
+          "go1.25.0.openbsd-riscv64.tar.gz",
+          "aa510ad25cf54c06cd9c70b6d80ded69cb20188ac6e1735655eef29ff7e7885f"
+        ],
+        "plan9_386": [
+          "go1.25.0.plan9-386.tar.gz",
+          "46f8cef02086cf04bf186c5912776b56535178d4cb319cd19c9fdbdd29231986"
+        ],
+        "plan9_amd64": [
+          "go1.25.0.plan9-amd64.tar.gz",
+          "29b34391d84095e44608a228f63f2f88113a37b74a79781353ec043dfbcb427b"
+        ],
+        "plan9_arm": [
+          "go1.25.0.plan9-arm.tar.gz",
+          "0a047107d13ebe7943aaa6d54b1d7bbd2e45e68ce449b52915a818da715799c2"
+        ],
+        "solaris_amd64": [
+          "go1.25.0.solaris-amd64.tar.gz",
+          "9977f9e4351984364a3b2b78f8b88bfd1d339812356d5237678514594b7d3611"
+        ],
+        "windows_386": [
+          "go1.25.0.windows-386.zip",
+          "df9f39db82a803af0db639e3613a36681ab7a42866b1384b3f3a1045663961a7"
+        ],
+        "windows_amd64": [
+          "go1.25.0.windows-amd64.zip",
+          "89efb4f9b30812eee083cc1770fdd2913c14d301064f6454851428f9707d190b"
+        ],
+        "windows_arm64": [
+          "go1.25.0.windows-arm64.zip",
+          "27bab004c72b3d7bd05a69b6ec0fc54a309b4b78cc569dd963d8b3ec28bfdb8c"
+        ]
+      },
+      "1.26.2": {
+        "aix_ppc64": [
+          "go1.26.2.aix-ppc64.tar.gz",
+          "e6f759fbdd5b1e3ecce3161d8bd9b9aeaf15c4112b7c101097e9d329b310d858"
+        ],
+        "darwin_amd64": [
+          "go1.26.2.darwin-amd64.tar.gz",
+          "bc3f1500d9968c36d705442d90ba91addf9271665033748b82532682e90a7966"
+        ],
+        "darwin_arm64": [
+          "go1.26.2.darwin-arm64.tar.gz",
+          "32af1522bf3e3ff3975864780a429cc0b41d190ec7bf90faa661d6d64566e7af"
+        ],
+        "dragonfly_amd64": [
+          "go1.26.2.dragonfly-amd64.tar.gz",
+          "b4f3f74412914e54140cbf8b5c76d2f8eeff3a5003310c9244c61ba8a0ecd94b"
+        ],
+        "freebsd_386": [
+          "go1.26.2.freebsd-386.tar.gz",
+          "fab09ea1988aae3ae2c8186455e8956d539d04e2ee4973e8887853432d0e8039"
+        ],
+        "freebsd_amd64": [
+          "go1.26.2.freebsd-amd64.tar.gz",
+          "f271fd829a2a6b36fa1c72cdaafb18410a106da982c93a626d4e8b0fa0f0fa21"
+        ],
+        "freebsd_arm": [
+          "go1.26.2.freebsd-arm.tar.gz",
+          "38713f1516cd2b0097ea05594ec1c842fe690dace8301c7d34d91b92250b4424"
+        ],
+        "freebsd_arm64": [
+          "go1.26.2.freebsd-arm64.tar.gz",
+          "d78bb171900134efdd1d0d49e5e80cd8c8b614f0e46c508d0b6bac30fb996fdf"
+        ],
+        "illumos_amd64": [
+          "go1.26.2.illumos-amd64.tar.gz",
+          "e88cd85e9e253ceda4077367072aa10d2f92bc2fa6e59a811c00bbe95dc9b02d"
+        ],
+        "linux_386": [
+          "go1.26.2.linux-386.tar.gz",
+          "89835cdc4dfebde7fe28c9c6dc080bb3753f6b0354301966ff9f62d14991bd7d"
+        ],
+        "linux_amd64": [
+          "go1.26.2.linux-amd64.tar.gz",
+          "990e6b4bbba816dc3ee129eaeaf4b42f17c2800b88a2166c265ac1a200262282"
+        ],
+        "linux_arm64": [
+          "go1.26.2.linux-arm64.tar.gz",
+          "c958a1fe1b361391db163a485e21f5f228142d6f8b584f6bef89b26f66dc5b23"
+        ],
+        "linux_armv6l": [
+          "go1.26.2.linux-armv6l.tar.gz",
+          "0000e45577827b0a8868588c543cbe4232853def1d3d7a344ad6e60ce2b015c8"
+        ],
+        "linux_loong64": [
+          "go1.26.2.linux-loong64.tar.gz",
+          "4dcb87e845fe5c015c8cf6affb4636fcf1699182b70454783caed85c5dfa3267"
+        ],
+        "linux_mips": [
+          "go1.26.2.linux-mips.tar.gz",
+          "2d57e4167932a4872e31570465f48d8b6818002c77275bae969bdbb6d7238b5e"
+        ],
+        "linux_mips64": [
+          "go1.26.2.linux-mips64.tar.gz",
+          "b0b49bb5c528e623a926b8242f03cfd612971150e18eeb3f638d751218c09cdf"
+        ],
+        "linux_mips64le": [
+          "go1.26.2.linux-mips64le.tar.gz",
+          "5ffc9da2b0ee939c8503c9d9278d6857909ca8577dae3b71221ab2821dc7826a"
+        ],
+        "linux_mipsle": [
+          "go1.26.2.linux-mipsle.tar.gz",
+          "ab1fe1c38ffa6bbda029dea33bf36167aca4ff3a25c9d6ed0af38da120678ddc"
+        ],
+        "linux_ppc64": [
+          "go1.26.2.linux-ppc64.tar.gz",
+          "589f7ef241104f153e910244b71d70f4aad0d4584651ca80a5188186dda63a2e"
+        ],
+        "linux_ppc64le": [
+          "go1.26.2.linux-ppc64le.tar.gz",
+          "62b7645dd2404052535617c59e91cf03c7aa28e332dbaddbe4c0d7de7bcc6736"
+        ],
+        "linux_riscv64": [
+          "go1.26.2.linux-riscv64.tar.gz",
+          "c5c697faa4dc05364b6e163d2ab8161b32a120eeed54192457d57d7ef7c2091a"
+        ],
+        "linux_s390x": [
+          "go1.26.2.linux-s390x.tar.gz",
+          "410726ed10a0ea6745c2ea8da4f0e769fd3ce819cd4a41a67ad08b094d5dfc31"
+        ],
+        "netbsd_386": [
+          "go1.26.2.netbsd-386.tar.gz",
+          "e8ffab99dd65fef14097d6af48ea6302793f2298a7b2e5f00a284bd933feba4c"
+        ],
+        "netbsd_amd64": [
+          "go1.26.2.netbsd-amd64.tar.gz",
+          "1f5c33c923983ee8433ad8098dcd87a0e1fdccd18d05a91844c2be60507a61fe"
+        ],
+        "netbsd_arm": [
+          "go1.26.2.netbsd-arm.tar.gz",
+          "85761320e364b65424d2952a3388970d86e072c8dce8dcad2a1dca41555c2b96"
+        ],
+        "netbsd_arm64": [
+          "go1.26.2.netbsd-arm64.tar.gz",
+          "3ca3561bf4452e799d11e5312182f79cd342d506136cd44c2b47991206ec23f5"
+        ],
+        "openbsd_386": [
+          "go1.26.2.openbsd-386.tar.gz",
+          "0644073c0ae1ade26d26953ef882d7d419855dca25b0e992ae416a47967d37b3"
+        ],
+        "openbsd_amd64": [
+          "go1.26.2.openbsd-amd64.tar.gz",
+          "72f69217a88e3d0975a75adf9fc92ff10ea65def56e6c34d8612428bf769581e"
+        ],
+        "openbsd_arm": [
+          "go1.26.2.openbsd-arm.tar.gz",
+          "3aafe792df65abf1777b5cc678075ebba1bd8063e6450e81e742fef696e0bcbd"
+        ],
+        "openbsd_arm64": [
+          "go1.26.2.openbsd-arm64.tar.gz",
+          "efd410fc60a17690ad43fe8dd00bf1fd4c1dc920d81970b9f422f313b0930b92"
+        ],
+        "openbsd_ppc64": [
+          "go1.26.2.openbsd-ppc64.tar.gz",
+          "98a2cadd416066739e00b1bc297727c3108dba9001811b177ce57afef518f8bd"
+        ],
+        "openbsd_riscv64": [
+          "go1.26.2.openbsd-riscv64.tar.gz",
+          "adf39a1a7e56d5c1a2cb69ad06752c5da6b808d2a029b7b6d6d5bb6e11a2168e"
+        ],
+        "plan9_386": [
+          "go1.26.2.plan9-386.tar.gz",
+          "eb2f95f6f43701eb98a31f5efdd9b5f14ff6e0afd289e1f94559462f83e73cfd"
+        ],
+        "plan9_amd64": [
+          "go1.26.2.plan9-amd64.tar.gz",
+          "d347fecec7532309fccf3570021ba8a00a0acce120fea02a46cc295936588b0f"
+        ],
+        "plan9_arm": [
+          "go1.26.2.plan9-arm.tar.gz",
+          "70700c5af45201a8e82436fb824f3551e357e3002094c8416e78e1aa51d4a0ab"
+        ],
+        "solaris_amd64": [
+          "go1.26.2.solaris-amd64.tar.gz",
+          "cd45d13200697b3263e39cdf364f0cb9d9adc39d9574ab575e481b64cb7fb8b1"
+        ],
+        "windows_386": [
+          "go1.26.2.windows-386.zip",
+          "4a8b02c34625fecd9c6583442101c9796fc265a5fc1edb9340d71bed0300f94c"
+        ],
+        "windows_amd64": [
+          "go1.26.2.windows-amd64.zip",
+          "98eb3570bade15cb826b0909338df6cc6d2cf590bc39c471142002db3832b708"
+        ],
+        "windows_arm64": [
+          "go1.26.2.windows-arm64.zip",
+          "094d05caaf6ba235e2bd570b625d064ceb65943866252722a8f3fdba232139c6"
+        ]
+      }
+    }
+  }
 }

--- a/integration/basic/BUILD.bazel
+++ b/integration/basic/BUILD.bazel
@@ -1,12 +1,12 @@
 load(
     "@rules_nvc//build/nvc:rules.bzl",
-    "vhdl_elaborate",
-    "vhdl_library",
-    "vhdl_run",
+    "nvc_vhdl_elaborate",
+    "nvc_vhdl_library",
+    "nvc_vhdl_run",
 )
 load("@rules_nvc//internal:macros.bzl", "wave_view")
 
-vhdl_library(
+nvc_vhdl_library(
     name = "work",
     srcs = [
         "test.vhdl",
@@ -14,17 +14,17 @@ vhdl_library(
     entities = ["hello_world"],
 )
 
-vhdl_elaborate(
+nvc_vhdl_elaborate(
     name = "hello_world",
     library = ":work",
 )
 
-vhdl_run(
+nvc_vhdl_run(
     name = "sim",
     entity = ":hello_world",
 )
 
 wave_view(
     name = "wave",
-    vhdl_run = ":sim",
+    nvc_vhdl_run = ":sim",
 )

--- a/integration/cosim/BUILD.bazel
+++ b/integration/cosim/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@rules_nvc//internal:cosim.bzl", "nvc_verilator_cosim")
-load("@rules_nvc//nvc:rules.bzl", "vhdl_test")
+load("@rules_nvc//nvc:rules.bzl", "nvc_vhdl_test")
 
 nvc_verilator_cosim(
     name = "cosim_bridge",
@@ -8,7 +8,7 @@ nvc_verilator_cosim(
     path_prefix = ":top_tb:dut_inst",
 )
 
-vhdl_test(
+nvc_vhdl_test(
     name = "cosim_test",
     srcs = ["top_tb.vhdl"],
     deps = [

--- a/integration/cosim_manual_entity/BUILD.bazel
+++ b/integration/cosim_manual_entity/BUILD.bazel
@@ -1,7 +1,7 @@
 # LICENSE sha256: c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4
 
 load("@rules_nvc//internal:cosim.bzl", "nvc_verilator_cosim")
-load("@rules_nvc//nvc:rules.bzl", "vhdl_test", "vhdl_library")
+load("@rules_nvc//nvc:rules.bzl", "nvc_vhdl_test", "nvc_vhdl_library")
 
 # Generate only the architecture
 nvc_verilator_cosim(
@@ -14,7 +14,7 @@ nvc_verilator_cosim(
 
 # Manually defined entity combined with generated architecture
 # We name this cosim_bridge because top_tb.vhdl expects it.
-vhdl_library(
+nvc_vhdl_library(
     name = "cosim_bridge",
     srcs = [
         "dut_entity.vhdl",
@@ -25,7 +25,7 @@ vhdl_library(
     ],
 )
 
-vhdl_test(
+nvc_vhdl_test(
     name = "cosim_test",
     srcs = ["top_tb.vhdl"],
     deps = [

--- a/integration/cosim_param/BUILD.bazel
+++ b/integration/cosim_param/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@rules_nvc//internal:cosim.bzl", "nvc_verilator_cosim")
-load("@rules_nvc//nvc:rules.bzl", "vhdl_test")
+load("@rules_nvc//nvc:rules.bzl", "nvc_vhdl_test")
 
 nvc_verilator_cosim(
     name = "cosim_bridge",
@@ -11,7 +11,7 @@ nvc_verilator_cosim(
     },
 )
 
-vhdl_test(
+nvc_vhdl_test(
     name = "cosim_test",
     srcs = ["top_tb.vhdl"],
     deps = [

--- a/integration/cosim_separate/BUILD.bazel
+++ b/integration/cosim_separate/BUILD.bazel
@@ -1,7 +1,7 @@
 # LICENSE sha256: c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4
 
 load("@rules_nvc//internal:cosim.bzl", "nvc_verilator_cosim")
-load("@rules_nvc//nvc:rules.bzl", "vhdl_test", "vhdl_library")
+load("@rules_nvc//nvc:rules.bzl", "nvc_vhdl_test", "nvc_vhdl_library")
 
 nvc_verilator_cosim(
     name = "cosim_bridge",
@@ -11,7 +11,7 @@ nvc_verilator_cosim(
     separate_entity_arch = True,
 )
 
-vhdl_test(
+nvc_vhdl_test(
     name = "cosim_test",
     srcs = ["top_tb.vhdl"],
     deps = [

--- a/integration/demo/BUILD.bazel
+++ b/integration/demo/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@rules_nvc//internal:cosim.bzl", "nvc_verilator_cosim")
-load("@rules_nvc//nvc:rules.bzl", "vhdl_test")
+load("@rules_nvc//nvc:rules.bzl", "nvc_vhdl_test")
 
 nvc_verilator_cosim(
     name = "adder_bridge",
@@ -15,7 +15,7 @@ nvc_verilator_cosim(
     path_prefix = ":top_tb:counter_inst",
 )
 
-vhdl_test(
+nvc_vhdl_test(
     name = "demo_test",
     srcs = ["top_tb.vhdl"],
     deps = [

--- a/integration/sim/BUILD.bazel
+++ b/integration/sim/BUILD.bazel
@@ -1,6 +1,6 @@
-load("@rules_nvc//build/nvc:rules.bzl", "vhdl_elaborate", "vhdl_library", "vhdl_run", "vhdl_test")
+load("@rules_nvc//build/nvc:rules.bzl", "nvc_vhdl_elaborate", "nvc_vhdl_library", "nvc_vhdl_run", "nvc_vhdl_test")
 
-vhdl_library(
+nvc_vhdl_library(
     name = "sim",
     srcs = [
         "clkgen.vhdl",
@@ -8,7 +8,7 @@ vhdl_library(
     ],
 )
 
-vhdl_test(
+nvc_vhdl_test(
     name = "sim_test",
     srcs = [
         "clkgen_test.vhdl",

--- a/integration/systemverilog/BUILD.bazel
+++ b/integration/systemverilog/BUILD.bazel
@@ -1,8 +1,8 @@
-load("@rules_nvc//build/nvc:rules.bzl", "verilog_library")
+load("@rules_nvc//build/nvc:rules.bzl", "nvc_verilog_library")
 
 package(default_visibility = ["//visibility:public"])
 
-verilog_library(
+nvc_verilog_library(
     name = "nvc_verilog",
     srcs = [
         "counter.sv",
@@ -12,7 +12,7 @@ verilog_library(
     ],
 )
 
-verilog_library(
+nvc_verilog_library(
     name = "counter2",
     srcs = [
         "counter2.sv",

--- a/integration/two_libraries/BUILD.bazel
+++ b/integration/two_libraries/BUILD.bazel
@@ -1,11 +1,11 @@
 load(
     "@rules_nvc//build/nvc:rules.bzl",
-    "vhdl_elaborate",
-    "vhdl_library",
-    "vhdl_run",
+    "nvc_vhdl_elaborate",
+    "nvc_vhdl_library",
+    "nvc_vhdl_run",
 )
 
-vhdl_library(
+nvc_vhdl_library(
     name = "work",
     srcs = [
         "test.vhdl",
@@ -14,17 +14,17 @@ vhdl_library(
     deps = [":pkg"],
 )
 
-vhdl_elaborate(
+nvc_vhdl_elaborate(
     name = "hello_world",
     library = ":work",
 )
 
-vhdl_run(
+nvc_vhdl_run(
     name = "sim",
     entity = ":hello_world",
 )
 
-vhdl_library(
+nvc_vhdl_library(
     name = "pkg",
     srcs = [
         "package.vhdl",

--- a/internal/BUILD.bazel
+++ b/internal/BUILD.bazel
@@ -76,8 +76,8 @@ stardoc(
 )
 
 bzl_library(
-    name = "vhdl_elaborate",
-    srcs = ["vhdl_elaborate.bzl"],
+    name = "nvc_vhdl_elaborate",
+    srcs = ["nvc_vhdl_elaborate.bzl"],
     deps = [
         ":providers",
         ":toolchain",
@@ -86,15 +86,41 @@ bzl_library(
 )
 
 stardoc(
-    name = "md_vhdl_elaborate",
-    out = "gen.vhdl_elaborate.md",
-    input = "vhdl_elaborate.bzl",
-    deps = [":vhdl_elaborate"],
+    name = "md_nvc_vhdl_elaborate",
+    out = "gen.nvc_vhdl_elaborate.md",
+    input = "nvc_vhdl_elaborate.bzl",
+    deps = [":nvc_vhdl_elaborate"],
 )
 
 bzl_library(
-    name = "vhdl_library",
-    srcs = ["vhdl_library.bzl"],
+    name = "rules_vhdl_defs",
+    srcs = ["@rules_vhdl//vhdl:defs.bzl"],
+    deps = [
+        "@rules_vhdl//vhdl:defs_bzl",
+    ],
+)
+
+bzl_library(
+    name = "nvc_vhdl_library",
+    srcs = ["nvc_vhdl_library.bzl"],
+    deps = [
+        ":providers",
+        ":toolchain",
+        ":utils",
+        ":rules_vhdl_defs",
+    ],
+)
+
+stardoc(
+    name = "md_nvc_vhdl_library",
+    out = "gen.nvc_vhdl_library.md",
+    input = "nvc_vhdl_library.bzl",
+    deps = [":nvc_vhdl_library"],
+)
+
+bzl_library(
+    name = "nvc_vhdl_run",
+    srcs = ["nvc_vhdl_run.bzl"],
     deps = [
         ":providers",
         ":toolchain",
@@ -103,15 +129,31 @@ bzl_library(
 )
 
 stardoc(
-    name = "md_vhdl_library",
-    out = "gen.vhdl_library.md",
-    input = "vhdl_library.bzl",
-    deps = [":vhdl_library"],
+    name = "md_nvc_vhdl_run",
+    out = "gen.nvc_vhdl_run.md",
+    input = "nvc_vhdl_run.bzl",
+    deps = [":nvc_vhdl_run"],
 )
 
 bzl_library(
-    name = "vhdl_run",
-    srcs = ["vhdl_run.bzl"],
+    name = "nvc_vhdl_test",
+    srcs = ["nvc_vhdl_test.bzl"],
+    deps = [
+        ":nvc_vhdl_elaborate",
+        ":nvc_vhdl_library",
+    ],
+)
+
+stardoc(
+    name = "md_nvc_vhdl_test",
+    out = "gen.nvc_vhdl_test.md",
+    input = "nvc_vhdl_test.bzl",
+    deps = [":nvc_vhdl_test"],
+)
+
+bzl_library(
+    name = "nvc_verilog_library",
+    srcs = ["nvc_verilog_library.bzl"],
     deps = [
         ":providers",
         ":toolchain",
@@ -120,43 +162,10 @@ bzl_library(
 )
 
 stardoc(
-    name = "md_vhdl_run",
-    out = "gen.vhdl_run.md",
-    input = "vhdl_run.bzl",
-    deps = [":vhdl_run"],
-)
-
-bzl_library(
-    name = "vhdl_test",
-    srcs = ["vhdl_test.bzl"],
-    deps = [
-        ":vhdl_elaborate",
-        ":vhdl_library",
-    ],
-)
-
-stardoc(
-    name = "md_vhdl_test",
-    out = "gen.vhdl_test.md",
-    input = "vhdl_test.bzl",
-    deps = [":vhdl_test"],
-)
-
-bzl_library(
-    name = "verilog_library",
-    srcs = ["verilog_library.bzl"],
-    deps = [
-        ":providers",
-        ":toolchain",
-        ":utils",
-    ],
-)
-
-stardoc(
-    name = "md_verilog_library",
-    out = "gen.verilog_library.md",
-    input = "verilog_library.bzl",
-    deps = [":verilog_library"],
+    name = "md_nvc_verilog_library",
+    out = "gen.nvc_verilog_library.md",
+    input = "nvc_verilog_library.bzl",
+    deps = [":nvc_verilog_library"],
 )
 
 # Removed bzl_library for cosim because of external dependency issues.
@@ -200,11 +209,11 @@ write_source_files(
         "providers.md": ":md_providers",
         "toolchain.md": ":md_toolchain",
         "utils.md": ":md_utils",
-        "verilog_library.md": ":md_verilog_library",
-        "vhdl_elaborate.md": ":md_vhdl_elaborate",
-        "vhdl_library.md": ":md_vhdl_library",
-        "vhdl_run.md": ":md_vhdl_run",
-        "vhdl_test.md": ":md_vhdl_test",
+        "nvc_verilog_library.md": ":md_nvc_verilog_library",
+        "nvc_vhdl_elaborate.md": ":md_nvc_vhdl_elaborate",
+        "nvc_vhdl_library.md": ":md_nvc_vhdl_library",
+        "nvc_vhdl_run.md": ":md_nvc_vhdl_run",
+        "nvc_vhdl_test.md": ":md_nvc_vhdl_test",
     },
 )
 

--- a/internal/cosim.bzl
+++ b/internal/cosim.bzl
@@ -3,9 +3,9 @@
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("@rules_verilator//verilator:defs.bzl", "verilator_cc_library")
 load("@rules_verilog//verilog:defs.bzl", vlog_library = "verilog_library")
-load("//internal:vhdl_library.bzl", "vhdl_library")
-load("//internal:vhdl_elaborate.bzl", "vhdl_elaborate")
-load("//internal:vhdl_test.bzl", "vhdl_test")
+load("//internal:nvc_vhdl_library.bzl", "nvc_vhdl_library")
+load("//internal:nvc_vhdl_elaborate.bzl", "nvc_vhdl_elaborate")
+load("//internal:nvc_vhdl_test.bzl", "nvc_vhdl_test")
 
 def _verilator_json_impl(ctx):
     # Use the verilator toolchain
@@ -144,7 +144,7 @@ def nvc_verilator_cosim(name, srcs, top_module, path_prefix, parameters = {}, se
     """
     Macro that encapsulates NVC and Verilator co-simulation bindings generation.
     Generates the VHDL proxy and C++ bindings for the given Verilog top module.
-    The resulting VHDL file can be used as a dependency in a `vhdl_library`.
+    The resulting VHDL file can be used as a dependency in a `nvc_vhdl_library`.
     
     Args:
         name: Name of the generated rules.
@@ -242,7 +242,7 @@ def nvc_verilator_cosim(name, srcs, top_module, path_prefix, parameters = {}, se
             actual = vhdl_arch_target,
         )
 
-    vhdl_library(
+    nvc_vhdl_library(
         name = name,
         srcs = vhdl_srcs,
         vpi_plugins = [":{}".format(cc_name)],

--- a/internal/macros.bzl
+++ b/internal/macros.bzl
@@ -1,14 +1,14 @@
 load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
 
 
-def wave_view(name, vhdl_run, args=[], deps=[], viewer="gtkwave", testonly=None, save_file=None):
+def wave_view(name, nvc_vhdl_run, args=[], deps=[], viewer="gtkwave", testonly=None, save_file=None):
     """
     Generates a sh_binary viewer.
 
     # Args
 
     - name: the target name.
-    - vhdl_run: the target name for the `vhdl_run` target to
+    - nvc_vhdl_run: the target name for the `nvc_vhdl_run` target to
       use the output from.
     - args: any additional arguments to add to invoke the viewer.
     - viewer: the viewer to invoke. The viewer must be compatible
@@ -18,12 +18,12 @@ def wave_view(name, vhdl_run, args=[], deps=[], viewer="gtkwave", testonly=None,
     """
     _args = [
           "--viewer-binary={}".format(viewer),
-          "--wave-file=$(location {})".format(vhdl_run),
+          "--wave-file=$(location {})".format(nvc_vhdl_run),
           "--",
     ] + args
     _data = [
           "@gotopt2//:bin",
-          vhdl_run,
+          nvc_vhdl_run,
         ] + deps
     if save_file:
         _args += ["--save=$(location {})".format(save_file)]

--- a/internal/macros.md
+++ b/internal/macros.md
@@ -9,7 +9,7 @@
 <pre>
 load("@rules_nvc//internal:macros.bzl", "wave_view")
 
-wave_view(<a href="#wave_view-name">name</a>, <a href="#wave_view-vhdl_run">vhdl_run</a>, <a href="#wave_view-args">args</a>, <a href="#wave_view-deps">deps</a>, <a href="#wave_view-viewer">viewer</a>, <a href="#wave_view-testonly">testonly</a>, <a href="#wave_view-save_file">save_file</a>)
+wave_view(<a href="#wave_view-name">name</a>, <a href="#wave_view-nvc_vhdl_run">nvc_vhdl_run</a>, <a href="#wave_view-args">args</a>, <a href="#wave_view-deps">deps</a>, <a href="#wave_view-viewer">viewer</a>, <a href="#wave_view-testonly">testonly</a>, <a href="#wave_view-save_file">save_file</a>)
 </pre>
 
 Generates a sh_binary viewer.
@@ -17,7 +17,7 @@ Generates a sh_binary viewer.
 # Args
 
 - name: the target name.
-- vhdl_run: the target name for the `vhdl_run` target to
+- nvc_vhdl_run: the target name for the `nvc_vhdl_run` target to
   use the output from.
 - args: any additional arguments to add to invoke the viewer.
 - viewer: the viewer to invoke. The viewer must be compatible
@@ -30,7 +30,7 @@ Generates a sh_binary viewer.
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
 | <a id="wave_view-name"></a>name |  <p align="center"> - </p>   |  none |
-| <a id="wave_view-vhdl_run"></a>vhdl_run |  <p align="center"> - </p>   |  none |
+| <a id="wave_view-nvc_vhdl_run"></a>nvc_vhdl_run |  <p align="center"> - </p>   |  none |
 | <a id="wave_view-args"></a>args |  <p align="center"> - </p>   |  `[]` |
 | <a id="wave_view-deps"></a>deps |  <p align="center"> - </p>   |  `[]` |
 | <a id="wave_view-viewer"></a>viewer |  <p align="center"> - </p>   |  `"gtkwave"` |

--- a/internal/nvc_verilog_library.bzl
+++ b/internal/nvc_verilog_library.bzl
@@ -1,0 +1,136 @@
+load("//internal:utils.bzl", "get_single_file_from", "get_nvc_deps", "get_nvc_ld_library_path")
+load("//internal:providers.bzl", "NVCInfo", "VHDLLibraryProvider", "ElaborateProvider")
+load("//internal:toolchain.bzl",
+     _NVC_TOOLCHAIN_TYPE = "NVC_TOOLCHAIN_TYPE",
+     _NVC_WRAPPER = "NVC_WRAPPER",
+     _NVC_DIRECT_WRAPPER = "NVC_DIRECT_WRAPPER",
+    _VHDL_STANDARD_DEFAULT = "VHDL_STANDARD_DEFAULT",
+    _nvc_toolchain = "nvc_toolchain")
+
+
+def _impl(ctx):
+    nvc_info = ctx.toolchains[_NVC_TOOLCHAIN_TYPE].nvc_info
+    nvc_deps = get_nvc_deps(nvc_info)
+    analyzer_x = nvc_info.analyzer.files.to_list()[0]
+    analyzer = analyzer_x.path
+    library_name = ctx.attr.library_name or ctx.attr.name
+    container_dir = ctx.actions.declare_directory(
+        "{}".format(library_name)
+    )
+
+    artifacts = nvc_info.artifacts_dir.files.to_list()
+    std_lib_dir = artifacts[1] # hopefully stable...
+    
+    analyzer_dir = analyzer_x.dirname
+    base_dir = analyzer_dir[:-4] if analyzer_dir.endswith("/bin") else analyzer_dir
+
+    targets = ctx.attr.srcs
+    srcs = []
+    for target in targets:
+        files = target.files.to_list()
+        srcs += files
+
+    all_libraries = []
+    flag_libraries = []
+    include_dirs = []
+    include_dirs_only = []
+    deps_files = []
+    seen = []
+    deps_hdrs_depset = []
+    for target in ctx.attr.deps:
+        default_info = target[DefaultInfo]
+        deps_files += default_info.files.to_list()
+        vhdl_provider = target[VHDLLibraryProvider]
+        all_libraries += vhdl_provider.libraries
+        deps_hdrs_depset += [vhdl_provider.hdrs]
+        for name, path in vhdl_provider.libraries:
+            flag_libraries += ["-L", "{path}".format(path=path.path)]
+            seen += [name]
+        for include_dir in vhdl_provider.includes:
+            include_dirs += ["-I", include_dir]
+            include_dirs_only += [include_dir]
+    for include_dir in ctx.attr.includes:
+        include_dirs += ["-I", include_dir]
+        include_dirs_only += [include_dir]
+    for hdr_file in ctx.files.hdrs:
+        hdr_dir = hdr_file.dirname
+        include_dirs += ["-I", hdr_dir]
+        include_dirs_only += [hdr_dir]
+
+    all_hdrs_files = depset([], transitive=deps_hdrs_depset).to_list()
+
+    ctx.actions.run(
+        outputs = [container_dir],
+        inputs = srcs + deps_files + ctx.files.hdrs + all_hdrs_files + nvc_deps,
+        executable = ctx.executable._direct_wrapper,
+        env = {
+            "NVC_LD_LIBRARY_PATH": get_nvc_ld_library_path(nvc_info, base_dir, ctx.configuration.default_shell_env),
+        },
+        arguments = [
+          analyzer,
+          "--std={}".format(ctx.attr.standard),
+          "-L", "{}/nvc".format(std_lib_dir.path),
+        ] + flag_libraries + [
+          "--work={}:{}/{}".format(
+            library_name,
+            container_dir.path,
+            library_name,
+          ),
+          "-a",
+        ] + include_dirs + [f.path for f in srcs],
+        tools = [analyzer_x] + artifacts,
+        # Only seems to work from bazel 6.0.0 on.
+        #toolchain = _NVC_TOOLCHAIN_TYPE,
+        progress_message = "VHDL analyze: {}".format(library_name),
+    )
+    return [
+        VHDLLibraryProvider(
+            libraries = [(library_name, container_dir)] + all_libraries,
+            entities = ctx.attr.entities,
+            library_name = library_name,
+            library_dir = container_dir,
+            includes = include_dirs_only,
+            hdrs = depset(ctx.files.hdrs, transitive=deps_hdrs_depset)
+        ),
+        DefaultInfo(files = depset([container_dir]))
+    ]
+
+
+nvc_verilog_library = rule(
+    doc = "Compiles Verilog source files into a library using NVC.",
+    implementation = _impl,
+    attrs = {
+        "library_name": attr.string(
+            doc = "If the target name is not appropriate as a library name, provide one here",
+        ),
+        "srcs": attr.label_list(
+            allow_files = [".v", ".vh", ".sv", ".svh"],
+            doc = "List of Verilog source files.",
+        ),
+        "hdrs": attr.label_list(
+            allow_files = [".v", ".vh", ".sv", ".svh"],
+            doc = "List of Verilog header files.",
+        ),
+        "deps": attr.label_list(
+            doc = "List of dependency libraries.",
+        ),
+        "entities": attr.string_list(
+            doc = "List of entities provided by this library.",
+        ),
+        "standard": attr.string(
+            default = _VHDL_STANDARD_DEFAULT,
+            doc = "The VHDL standard to use for compilation.",
+        ),
+        "includes": attr.string_list(
+            doc = "list of verilog include directories",
+        ),
+        "_direct_wrapper": attr.label(
+            default = _NVC_DIRECT_WRAPPER,
+            executable = True,
+            cfg = "host",
+        ),
+    },
+    toolchains = [
+        _NVC_TOOLCHAIN_TYPE,
+    ],
+)

--- a/internal/nvc_verilog_library.md
+++ b/internal/nvc_verilog_library.md
@@ -1,0 +1,31 @@
+<!-- Generated with Stardoc: http://skydoc.bazel.build -->
+
+
+
+<a id="nvc_verilog_library"></a>
+
+## nvc_verilog_library
+
+<pre>
+load("@rules_nvc//internal:nvc_verilog_library.bzl", "nvc_verilog_library")
+
+nvc_verilog_library(<a href="#nvc_verilog_library-name">name</a>, <a href="#nvc_verilog_library-deps">deps</a>, <a href="#nvc_verilog_library-srcs">srcs</a>, <a href="#nvc_verilog_library-hdrs">hdrs</a>, <a href="#nvc_verilog_library-entities">entities</a>, <a href="#nvc_verilog_library-includes">includes</a>, <a href="#nvc_verilog_library-library_name">library_name</a>, <a href="#nvc_verilog_library-standard">standard</a>)
+</pre>
+
+Compiles Verilog source files into a library using NVC.
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="nvc_verilog_library-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="nvc_verilog_library-deps"></a>deps |  List of dependency libraries.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="nvc_verilog_library-srcs"></a>srcs |  List of Verilog source files.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="nvc_verilog_library-hdrs"></a>hdrs |  List of Verilog header files.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="nvc_verilog_library-entities"></a>entities |  List of entities provided by this library.   | List of strings | optional |  `[]`  |
+| <a id="nvc_verilog_library-includes"></a>includes |  list of verilog include directories   | List of strings | optional |  `[]`  |
+| <a id="nvc_verilog_library-library_name"></a>library_name |  If the target name is not appropriate as a library name, provide one here   | String | optional |  `""`  |
+| <a id="nvc_verilog_library-standard"></a>standard |  The VHDL standard to use for compilation.   | String | optional |  `"2019"`  |
+
+

--- a/internal/nvc_vhdl_elaborate.bzl
+++ b/internal/nvc_vhdl_elaborate.bzl
@@ -1,0 +1,123 @@
+load("//internal:utils.bzl", "get_single_file_from", "get_nvc_deps", "get_nvc_ld_library_path")
+load("//internal:providers.bzl", "NVCInfo", "VHDLLibraryProvider", "ElaborateProvider")
+load("//internal:toolchain.bzl",
+     _NVC_TOOLCHAIN_TYPE = "NVC_TOOLCHAIN_TYPE",
+     _NVC_WRAPPER = "NVC_WRAPPER",
+    _VHDL_STANDARD_DEFAULT = "VHDL_STANDARD_DEFAULT",
+    _nvc_toolchain = "nvc_toolchain")
+
+
+def _nvc_vhdl_elaborate(ctx):
+    nvc_info = ctx.toolchains[_NVC_TOOLCHAIN_TYPE].nvc_info
+    nvc_deps = get_nvc_deps(nvc_info)
+    analyzer_x = nvc_info.analyzer.files.to_list()[0]
+    analyzer = analyzer_x.path
+
+    vhdl_provider = ctx.attr.library[VHDLLibraryProvider]
+    library_name = vhdl_provider.library_name
+    out_dir = ctx.actions.declare_directory("{}_out".format(library_name))
+
+    artifacts = nvc_info.artifacts_dir.files.to_list()
+    std_lib_dir = None
+    for artifact in artifacts:
+        if artifact.path.endswith("usr/lib/x86_64-linux-gnu/nvc"):
+            std_lib_dir = artifact
+            break
+            
+    if not std_lib_dir:
+        for artifact in artifacts:
+             if artifact.path.endswith("usr/lib/x86_64-linux-gnu/nvc/std/STD.STANDARD"):
+                 std_lib_dir = artifact.dirname
+                 break
+                 
+    analyzer_dir = analyzer_x.dirname
+    base_dir = analyzer_dir[:-4] if analyzer_dir.endswith("/bin") else analyzer_dir
+    nvc_lib_path = base_dir + "/lib/x86_64-linux-gnu/nvc"
+
+
+    all_libraries = []
+    flag_libraries = []
+    deps_paths = []
+    seen = []
+
+    vhdl_provider = ctx.attr.library[VHDLLibraryProvider]
+    all_libraries += vhdl_provider.libraries
+    for name, path in vhdl_provider.libraries:
+        if name != vhdl_provider.library_name and name not in seen:
+            flag_libraries += ["-L", path.path]
+            deps_paths += [path]
+            seen += [name]
+
+    runfiles = ctx.runfiles(files=deps_paths + [out_dir])
+
+    runfiles.merge_all([ctx.attr.library[DefaultInfo].default_runfiles])
+
+    work_library_file = get_single_file_from(ctx.attr.library)
+    vpi_plugins = []
+    vpi_flags = []
+    if hasattr(vhdl_provider, "vpi_plugins") and vhdl_provider.vpi_plugins:
+        vpi_plugins = vhdl_provider.vpi_plugins.to_list()
+        for p in vpi_plugins:
+            vpi_flags.append("--load=" + p.path)
+
+    ctx.actions.run(
+        outputs = [out_dir],
+        inputs = depset(direct = [vhdl_provider.library_dir] + ([std_lib_dir] if hasattr(std_lib_dir, "path") else []) + artifacts + nvc_deps + deps_paths + vpi_plugins).to_list(),
+        executable = ctx.executable._script.path,
+        env = {
+            "NVC_LD_LIBRARY_PATH": get_nvc_ld_library_path(nvc_info, base_dir, ctx.configuration.default_shell_env),
+        },
+        arguments = [
+            "--vhdl-standard={}".format(ctx.attr.standard),
+            "--nvc-binary-path={}".format(analyzer),
+            "--library-name={}".format(library_name),
+            "--library-paths={}".format(" ".join(flag_libraries + ["-L", nvc_lib_path])),
+            "--stdlib-dir={}".format(nvc_lib_path[:-4]), # /nvc is appended in wrapper
+            "--entity={}".format(ctx.attr.name),
+            "--library-dir-in-path={}".format(work_library_file.path),
+            "--library-dir-out-path={}".format(out_dir.path),
+            "--",
+        ] + vpi_flags,
+        tools = [analyzer_x, ctx.executable._script] + artifacts,
+        # Only seems to work from bazel 6.0.0 on.
+        #toolchain = _NVC_TOOLCHAIN_TYPE,
+        progress_message = "Elaborating VHDL: {}.{} at {}".format(
+            vhdl_provider.library_name, ctx.attr.name, work_library_file.path),
+    )
+    return  [
+        VHDLLibraryProvider(
+            libraries = vhdl_provider.libraries + all_libraries,
+            entities = vhdl_provider.entities,
+            library_name = library_name,
+            library_dir = out_dir,
+            vpi_plugins = vhdl_provider.vpi_plugins,
+        ),
+        ElaborateProvider(entity=ctx.attr.name),
+        DefaultInfo(
+            files=depset([out_dir]),
+            runfiles=runfiles,
+        ),
+    ]
+
+nvc_vhdl_elaborate = rule(
+    doc = "Elaborates a VHDL design using NVC.",
+    implementation = _nvc_vhdl_elaborate,
+    attrs = {
+        "library": attr.label(
+            doc = "The `nvc_vhdl_library` target to elaborate.",
+        ),
+        "_script": attr.label(
+            default = _NVC_WRAPPER,
+            executable = True,
+            cfg = "host",
+            doc = "Wrapper script to run NVC.",
+        ),
+        "standard": attr.string(
+            default = _VHDL_STANDARD_DEFAULT,
+            doc = "The VHDL standard to use for elaboration (e.g., '2019').",
+        ),
+    },
+    toolchains = [
+        _NVC_TOOLCHAIN_TYPE
+    ],
+)

--- a/internal/nvc_vhdl_elaborate.md
+++ b/internal/nvc_vhdl_elaborate.md
@@ -1,0 +1,26 @@
+<!-- Generated with Stardoc: http://skydoc.bazel.build -->
+
+
+
+<a id="nvc_vhdl_elaborate"></a>
+
+## nvc_vhdl_elaborate
+
+<pre>
+load("@rules_nvc//internal:nvc_vhdl_elaborate.bzl", "nvc_vhdl_elaborate")
+
+nvc_vhdl_elaborate(<a href="#nvc_vhdl_elaborate-name">name</a>, <a href="#nvc_vhdl_elaborate-library">library</a>, <a href="#nvc_vhdl_elaborate-standard">standard</a>)
+</pre>
+
+Elaborates a VHDL design using NVC.
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="nvc_vhdl_elaborate-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="nvc_vhdl_elaborate-library"></a>library |  The `nvc_vhdl_library` target to elaborate.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
+| <a id="nvc_vhdl_elaborate-standard"></a>standard |  The VHDL standard to use for elaboration (e.g., '2019').   | String | optional |  `"2019"`  |
+
+

--- a/internal/nvc_vhdl_library.bzl
+++ b/internal/nvc_vhdl_library.bzl
@@ -1,0 +1,242 @@
+load("@rules_vhdl//vhdl:defs.bzl", "VhdlInfo")
+load("//internal:utils.bzl", "get_single_file_from", "get_nvc_deps", "get_nvc_ld_library_path")
+load("//internal:providers.bzl", "NVCInfo", "VHDLLibraryProvider", "ElaborateProvider")
+load("//internal:toolchain.bzl",
+     _NVC_TOOLCHAIN_TYPE = "NVC_TOOLCHAIN_TYPE",
+     _NVC_WRAPPER = "NVC_WRAPPER",
+     _NVC_DIRECT_WRAPPER = "NVC_DIRECT_WRAPPER",
+    _VHDL_STANDARD_DEFAULT = "VHDL_STANDARD_DEFAULT",
+    _nvc_toolchain = "nvc_toolchain")
+
+
+def _nvc_vhdl_library(ctx):
+    nvc_info = ctx.toolchains[_NVC_TOOLCHAIN_TYPE].nvc_info
+    nvc_deps = get_nvc_deps(nvc_info)
+    analyzer_x = nvc_info.analyzer.files.to_list()[0]
+    analyzer = analyzer_x.path
+    library_name = ctx.attr.library_name or ctx.attr.name
+    container_dir = ctx.actions.declare_directory(
+        "{}".format(library_name)
+    )
+
+    artifacts = nvc_info.artifacts_dir.files.to_list()
+    std_lib_dir = None
+    for artifact in artifacts:
+        if artifact.path.endswith("usr/lib/x86_64-linux-gnu/nvc"):
+            std_lib_dir = artifact
+            break
+
+    if not std_lib_dir:
+        # Fallback if specific directory match fails, try to find a known file
+        for artifact in artifacts:
+             if artifact.path.endswith("usr/lib/x86_64-linux-gnu/nvc/std/STD.STANDARD"):
+                 std_lib_dir = artifact.dirname
+                 # dirname of std/STD.STANDARD is std, we need the parent 'nvc'
+                 # We'll just construct the path directly below
+                 break
+
+    # Construct the path to the nvc library directory based on the analyzer path
+    # Analyzer is at external/nvc_deb/usr/bin/nvc
+    # Library is at external/nvc_deb/usr/lib/x86_64-linux-gnu/nvc
+    analyzer_dir = analyzer_x.dirname
+    # Assuming path is .../usr/bin
+    base_dir = analyzer_dir[:-4] if analyzer_dir.endswith("/bin") else analyzer_dir
+    nvc_lib_path = base_dir + "/lib/x86_64-linux-gnu/nvc"
+
+    targets = ctx.attr.srcs
+    srcs = []
+    for target in targets:
+        files = target.files.to_list()
+        srcs += files
+
+    all_libraries = []
+    flag_libraries = []
+    deps_files = []
+    seen = []
+    vpi_plugins = []
+    for target in ctx.attr.deps:
+        default_info = target[DefaultInfo]
+        deps_files += default_info.files.to_list()
+        vhdl_provider = target[VHDLLibraryProvider]
+        all_libraries += vhdl_provider.libraries
+        if hasattr(vhdl_provider, "vpi_plugins"):
+            vpi_plugins.append(vhdl_provider.vpi_plugins)
+        for name, path in vhdl_provider.libraries:
+            flag_libraries += ["-L", "{path}".format(path=path.path)]
+            seen += [name]
+
+    # Add VPI plugins from this target
+    vpi_plugins.append(depset(ctx.files.vpi_plugins))
+
+
+    ctx.actions.run(
+        outputs = [container_dir],
+        inputs = srcs + deps_files + nvc_deps,
+        executable = ctx.executable._direct_wrapper,
+        env = {
+            "NVC_LD_LIBRARY_PATH": get_nvc_ld_library_path(nvc_info, base_dir, ctx.configuration.default_shell_env),
+        },
+        arguments = [
+          analyzer,
+          "--std={}".format(ctx.attr.standard),
+          "-L", nvc_lib_path,
+        ] + flag_libraries + [
+          "--work={}:{}/{}".format(
+            library_name,
+            container_dir.path,
+            library_name,
+          ),
+          "-a",
+        ] + [f.path for f in srcs],
+        tools = [analyzer_x] + artifacts,
+        # Only seems to work from bazel 6.0.0 on.
+        #toolchain = _NVC_TOOLCHAIN_TYPE,
+        progress_message = "VHDL analyze: {}".format(library_name),
+    )
+    return [
+        VHDLLibraryProvider(
+            libraries = [(library_name, container_dir)] + all_libraries,
+            entities = ctx.attr.entities,
+            library_name = library_name,
+            library_dir = container_dir,
+            vpi_plugins = depset(transitive = vpi_plugins),
+        ),
+        DefaultInfo(files = depset([container_dir]))
+    ]
+
+nvc_vhdl_library = rule(
+    doc = "Compiles VHDL source files into a library using NVC.",
+    implementation = _nvc_vhdl_library,
+    attrs = {
+        "library_name": attr.string(
+            doc = "If the target name is not appropriate as a library name, provide one here",
+        ),
+        "srcs": attr.label_list(
+            allow_files = [".vhdl", ".vhd"],
+            doc = "A list of VHDL source files.",
+        ),
+        "deps": attr.label_list(
+            doc = "A list of other `nvc_vhdl_library` targets that this library depends on.",
+        ),
+        "entities": attr.string_list(
+            doc = "A list of VHDL entities provided by this library.",
+        ),
+        "standard": attr.string(
+            default = _VHDL_STANDARD_DEFAULT,
+            doc = "The VHDL standard to use for compilation (e.g., '2008', '2019'). Defaults to '2019'.",
+        ),
+        "vpi_plugins": attr.label_list(
+            allow_files = True,
+            doc = "List of VPI plugins required for simulation.",
+        ),
+        "_direct_wrapper": attr.label(
+            default = _NVC_DIRECT_WRAPPER,
+            executable = True,
+            cfg = "host",
+        ),
+    },
+    toolchains = [
+        _NVC_TOOLCHAIN_TYPE,
+    ],
+)
+
+
+
+def _nvc_compile_aspect_impl(target, ctx):
+    if not VhdlInfo in target:
+        return []
+
+    nvc_info = ctx.toolchains[_NVC_TOOLCHAIN_TYPE].nvc_info
+    nvc_deps = get_nvc_deps(nvc_info)
+    analyzer_x = nvc_info.analyzer.files.to_list()[0]
+    analyzer = analyzer_x.path
+
+    vhdl_info = target[VhdlInfo]
+    library_name = vhdl_info.library or "work"
+
+    container_dir = ctx.actions.declare_directory(
+        "{}_nvc".format(target.label.name)
+    )
+
+    artifacts = nvc_info.artifacts_dir.files.to_list()
+    std_lib_dir = None
+    for artifact in artifacts:
+        if artifact.path.endswith("usr/lib/x86_64-linux-gnu/nvc"):
+            std_lib_dir = artifact
+            break
+
+    if not std_lib_dir:
+        for artifact in artifacts:
+             if artifact.path.endswith("usr/lib/x86_64-linux-gnu/nvc/std/STD.STANDARD"):
+                 std_lib_dir = artifact.dirname
+                 break
+
+    analyzer_dir = analyzer_x.dirname
+    base_dir = analyzer_dir[:-4] if analyzer_dir.endswith("/bin") else analyzer_dir
+    nvc_lib_path = base_dir + "/lib/x86_64-linux-gnu/nvc"
+
+    srcs = vhdl_info.srcs.to_list()
+
+    all_libraries = []
+    flag_libraries = []
+    deps_files = []
+    seen = []
+
+    for dep in ctx.rule.attr.deps:
+        if VHDLLibraryProvider in dep:
+            vhdl_provider = dep[VHDLLibraryProvider]
+            all_libraries += vhdl_provider.libraries
+            for name, path in vhdl_provider.libraries:
+                if name not in seen:
+                    flag_libraries += ["-L", "{path}".format(path=path.path)]
+                    seen += [name]
+            deps_files += dep[DefaultInfo].files.to_list()
+
+    ctx.actions.run(
+        outputs = [container_dir],
+        inputs = srcs + deps_files + nvc_deps,
+        executable = ctx.executable._direct_wrapper,
+        env = {
+            "NVC_LD_LIBRARY_PATH": get_nvc_ld_library_path(nvc_info, base_dir, ctx.configuration.default_shell_env),
+        },
+        arguments = [
+          analyzer,
+          "--std={}".format(vhdl_info.standard or _VHDL_STANDARD_DEFAULT),
+          "-L", nvc_lib_path,
+        ] + flag_libraries + [
+          "--work={}:{}/{}".format(
+            library_name,
+            container_dir.path,
+            library_name,
+          ),
+          "-a",
+        ] + [f.path for f in srcs],
+        tools = [analyzer_x] + artifacts,
+        progress_message = "VHDL analyze: {}".format(library_name),
+    )
+
+    return [
+        VHDLLibraryProvider(
+            libraries = [(library_name, container_dir)] + all_libraries,
+            entities = [],
+            library_name = library_name,
+            library_dir = container_dir,
+            vpi_plugins = depset(),
+        ),
+        DefaultInfo(files = depset([container_dir]))
+    ]
+
+nvc_compile_aspect = aspect(
+    implementation = _nvc_compile_aspect_impl,
+    attr_aspects = ["deps"],
+    attrs = {
+        "_direct_wrapper": attr.label(
+            default = _NVC_DIRECT_WRAPPER,
+            executable = True,
+            cfg = "host",
+        ),
+    },
+    toolchains = [
+        _NVC_TOOLCHAIN_TYPE,
+    ],
+)

--- a/internal/nvc_vhdl_library.md
+++ b/internal/nvc_vhdl_library.md
@@ -1,0 +1,54 @@
+<!-- Generated with Stardoc: http://skydoc.bazel.build -->
+
+
+
+<a id="nvc_vhdl_library"></a>
+
+## nvc_vhdl_library
+
+<pre>
+load("@rules_nvc//internal:nvc_vhdl_library.bzl", "nvc_vhdl_library")
+
+nvc_vhdl_library(<a href="#nvc_vhdl_library-name">name</a>, <a href="#nvc_vhdl_library-deps">deps</a>, <a href="#nvc_vhdl_library-srcs">srcs</a>, <a href="#nvc_vhdl_library-entities">entities</a>, <a href="#nvc_vhdl_library-library_name">library_name</a>, <a href="#nvc_vhdl_library-standard">standard</a>, <a href="#nvc_vhdl_library-vpi_plugins">vpi_plugins</a>)
+</pre>
+
+Compiles VHDL source files into a library using NVC.
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="nvc_vhdl_library-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="nvc_vhdl_library-deps"></a>deps |  A list of other `nvc_vhdl_library` targets that this library depends on.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="nvc_vhdl_library-srcs"></a>srcs |  A list of VHDL source files.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="nvc_vhdl_library-entities"></a>entities |  A list of VHDL entities provided by this library.   | List of strings | optional |  `[]`  |
+| <a id="nvc_vhdl_library-library_name"></a>library_name |  If the target name is not appropriate as a library name, provide one here   | String | optional |  `""`  |
+| <a id="nvc_vhdl_library-standard"></a>standard |  The VHDL standard to use for compilation (e.g., '2008', '2019'). Defaults to '2019'.   | String | optional |  `"2019"`  |
+| <a id="nvc_vhdl_library-vpi_plugins"></a>vpi_plugins |  List of VPI plugins required for simulation.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+
+
+<a id="nvc_compile_aspect"></a>
+
+## nvc_compile_aspect
+
+<pre>
+load("@rules_nvc//internal:nvc_vhdl_library.bzl", "nvc_compile_aspect")
+
+nvc_compile_aspect()
+</pre>
+
+
+
+**ASPECT ATTRIBUTES**
+
+
+| Name | Type |
+| :------------- | :------------- |
+| deps| String |
+
+
+**ATTRIBUTES**
+
+
+

--- a/internal/nvc_vhdl_run.bzl
+++ b/internal/nvc_vhdl_run.bzl
@@ -1,0 +1,145 @@
+load("//internal:utils.bzl", "get_single_file_from", "get_nvc_deps", "get_nvc_ld_library_path")
+load("//internal:providers.bzl", "NVCInfo", "VHDLLibraryProvider", "ElaborateProvider")
+load("//internal:toolchain.bzl",
+     _NVC_TOOLCHAIN_TYPE = "NVC_TOOLCHAIN_TYPE",
+     _NVC_WRAPPER = "NVC_WRAPPER",
+    _VHDL_STANDARD_DEFAULT = "VHDL_STANDARD_DEFAULT",
+    _nvc_toolchain = "nvc_toolchain")
+
+
+def _nvc_vhdl_run(ctx):
+    nvc_info = ctx.toolchains[_NVC_TOOLCHAIN_TYPE].nvc_info
+    nvc_deps = get_nvc_deps(nvc_info)
+    analyzer_x = nvc_info.analyzer.files.to_list()[0]
+    analyzer = analyzer_x.path
+    library_name = ctx.attr.name
+
+    artifacts = nvc_info.artifacts_dir.files.to_list()
+    std_lib_dir = None
+    for artifact in artifacts:
+        if artifact.path.endswith("usr/lib/x86_64-linux-gnu/nvc"):
+            std_lib_dir = artifact
+            break
+            
+    if not std_lib_dir:
+        for artifact in artifacts:
+             if artifact.path.endswith("usr/lib/x86_64-linux-gnu/nvc/std/STD.STANDARD"):
+                 std_lib_dir = artifact.dirname
+                 break
+
+    analyzer_dir = analyzer_x.dirname
+    base_dir = analyzer_dir[:-4] if analyzer_dir.endswith("/bin") else analyzer_dir
+    nvc_lib_path = base_dir + "/lib/x86_64-linux-gnu/nvc"
+
+
+    vhdl_provider = ctx.attr.entity[VHDLLibraryProvider]
+
+    all_libraries = []
+    flag_libraries = []
+    deps_paths = []
+    seen = []
+    all_libraries += vhdl_provider.libraries
+    for name, path in vhdl_provider.libraries:
+        if name != vhdl_provider.library_name and name not in seen:
+            flag_libraries += [
+                "--map={}:{}/{}".format(name, path.path, name)]
+            deps_paths += [path]
+            seen += [name]
+
+
+    work_library_file = get_single_file_from(ctx.attr.entity)
+
+    ext = "vcd"
+    if ctx.attr.use_fst:
+        ext = "fst"
+
+    wave_file = ctx.actions.declare_file(
+        "{}.{}".format(ctx.attr.name, ext))
+
+    format = []
+    if ctx.attr.use_fst:
+        format = [ "--format=fst" ]
+    elif ctx.attr.use_vcd:
+        format = [ "--format=vcd" ]
+
+    elaborate_provider = ctx.attr.entity[ElaborateProvider]
+
+    vpi_plugins = vhdl_provider.vpi_plugins.to_list()
+    vpi_flags = []
+    for p in vpi_plugins:
+        vpi_flags += ["-m", p.path]
+
+    runfiles = ctx.runfiles(files = [wave_file] + vpi_plugins)
+    ctx.actions.run(
+        outputs = [wave_file],
+        inputs = depset(direct = deps_paths + [vhdl_provider.library_dir] + ([std_lib_dir] if hasattr(std_lib_dir, "path") else []) + artifacts + nvc_deps + vpi_plugins).to_list(),
+        executable = ctx.executable._script.path,
+        env = {
+            "NVC_LD_LIBRARY_PATH": get_nvc_ld_library_path(nvc_info, base_dir, ctx.configuration.default_shell_env),
+        },
+        arguments = [
+            "-cmd=-r",
+            "--vhdl-standard={}".format(ctx.attr.standard),
+            "--nvc-binary-path={}".format(analyzer),
+            "--library-name={}".format(vhdl_provider.library_name),
+            "--library-paths={}".format(" ".join(flag_libraries + ["-L", nvc_lib_path])),
+            "--stdlib-dir={}".format(nvc_lib_path[:-4]),
+            "--entity={}".format(elaborate_provider.entity),
+            "--library-dir-in-path={}".format(work_library_file.path),
+            "--library-dir-out-path={}".format(work_library_file.path),
+            "--",
+        ] + vpi_flags + ctx.attr.args + [
+            "--wave={}".format(wave_file.path),
+        ] + format,
+        tools = [analyzer_x, ctx.executable._script] + artifacts,
+        # Only seems to work from bazel 6.0.0 on.
+        #toolchain = _NVC_TOOLCHAIN_TYPE,
+        progress_message = "Simulating VHDL: {}.{} at {}".format(
+            vhdl_provider.library_name,
+            elaborate_provider.entity,
+            work_library_file.path),
+    )
+    return [
+        DefaultInfo(
+            files=depset([wave_file]),
+            runfiles=runfiles,
+        ),
+    ]
+
+nvc_vhdl_run = rule(
+    doc = "Simulates an elaborated VHDL design using NVC.",
+    implementation = _nvc_vhdl_run,
+    attrs = {
+        "entity": attr.label(
+            doc = "The elaborated VHDL entity to simulate. This should be a `nvc_vhdl_elaborate` target.",
+        ),
+        "deps": attr.label_list(
+            default = [],
+            doc = "A list of other `nvc_vhdl_library` targets that this simulation depends on.",
+        ),
+        "_script": attr.label(
+            default = _NVC_WRAPPER,
+            executable = True,
+            cfg = "host",
+            doc = "Wrapper script to run NVC.",
+        ),
+        "standard": attr.string(
+            default = _VHDL_STANDARD_DEFAULT,
+            doc = "The VHDL standard to use for simulation. Defaults to '2019'.",
+        ),
+        "use_vcd": attr.bool(
+            default = True,
+            doc = "A boolean indicating whether to generate a VCD (Value Change Dump) file for waveform viewing. Defaults to `True`.",
+        ),
+        "use_fst": attr.bool(
+            default = False,
+            doc = "A boolean indicating whether to generate a FST file for waveform viewing. Defaults to `False`. Takes precedence over `use_vcd`.",
+        ),
+        "args": attr.string_list(
+            doc = "A list of added command line args to use",
+        ),
+    },
+    toolchains = [
+      _NVC_TOOLCHAIN_TYPE,
+    ],
+)

--- a/internal/nvc_vhdl_run.md
+++ b/internal/nvc_vhdl_run.md
@@ -1,0 +1,30 @@
+<!-- Generated with Stardoc: http://skydoc.bazel.build -->
+
+
+
+<a id="nvc_vhdl_run"></a>
+
+## nvc_vhdl_run
+
+<pre>
+load("@rules_nvc//internal:nvc_vhdl_run.bzl", "nvc_vhdl_run")
+
+nvc_vhdl_run(<a href="#nvc_vhdl_run-name">name</a>, <a href="#nvc_vhdl_run-deps">deps</a>, <a href="#nvc_vhdl_run-args">args</a>, <a href="#nvc_vhdl_run-entity">entity</a>, <a href="#nvc_vhdl_run-standard">standard</a>, <a href="#nvc_vhdl_run-use_fst">use_fst</a>, <a href="#nvc_vhdl_run-use_vcd">use_vcd</a>)
+</pre>
+
+Simulates an elaborated VHDL design using NVC.
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="nvc_vhdl_run-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="nvc_vhdl_run-deps"></a>deps |  A list of other `nvc_vhdl_library` targets that this simulation depends on.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="nvc_vhdl_run-args"></a>args |  A list of added command line args to use   | List of strings | optional |  `[]`  |
+| <a id="nvc_vhdl_run-entity"></a>entity |  The elaborated VHDL entity to simulate. This should be a `nvc_vhdl_elaborate` target.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
+| <a id="nvc_vhdl_run-standard"></a>standard |  The VHDL standard to use for simulation. Defaults to '2019'.   | String | optional |  `"2019"`  |
+| <a id="nvc_vhdl_run-use_fst"></a>use_fst |  A boolean indicating whether to generate a FST file for waveform viewing. Defaults to `False`. Takes precedence over `use_vcd`.   | Boolean | optional |  `False`  |
+| <a id="nvc_vhdl_run-use_vcd"></a>use_vcd |  A boolean indicating whether to generate a VCD (Value Change Dump) file for waveform viewing. Defaults to `True`.   | Boolean | optional |  `True`  |
+
+

--- a/internal/nvc_vhdl_test.bzl
+++ b/internal/nvc_vhdl_test.bzl
@@ -1,0 +1,202 @@
+load("//internal:utils.bzl", "get_single_file_from", "get_nvc_ld_library_path")
+load("//internal:providers.bzl", "NVCInfo", "VHDLLibraryProvider", "ElaborateProvider")
+load("//internal:toolchain.bzl",
+     _NVC_TOOLCHAIN_TYPE = "NVC_TOOLCHAIN_TYPE",
+     _NVC_WRAPPER = "NVC_WRAPPER",
+    _VHDL_STANDARD_DEFAULT = "VHDL_STANDARD_DEFAULT",
+    _nvc_toolchain = "nvc_toolchain")
+
+
+load("//internal:nvc_vhdl_library.bzl", "nvc_vhdl_library")
+load("//internal:nvc_vhdl_elaborate.bzl", "nvc_vhdl_elaborate")
+
+
+def _nvc_vhdl_test(ctx):
+    """
+    Mostly copied from _nvc_vhdl_run
+    """
+    nvc_info = ctx.toolchains[_NVC_TOOLCHAIN_TYPE].nvc_info
+    analyzer_x = nvc_info.analyzer.files.to_list()[0]
+    analyzer = analyzer_x.short_path
+    library_name = ctx.attr.name
+
+    artifacts = nvc_info.artifacts_dir.files.to_list()
+    std_lib_dir = None
+    for artifact in artifacts:
+        if artifact.path.endswith("usr/lib/x86_64-linux-gnu/nvc"):
+            std_lib_dir = artifact
+            break
+            
+    if not std_lib_dir:
+        for artifact in artifacts:
+             if artifact.path.endswith("usr/lib/x86_64-linux-gnu/nvc/std/STD.STANDARD"):
+                 std_lib_dir = artifact.dirname
+                 break
+
+    analyzer_dir = analyzer_x.dirname
+    base_dir = analyzer_dir[:-4] if analyzer_dir.endswith("/bin") else analyzer_dir
+    nvc_lib_path = base_dir + "/lib/x86_64-linux-gnu/nvc"
+
+
+    vhdl_provider = ctx.attr.entity[VHDLLibraryProvider]
+
+    all_libraries = []
+    flag_libraries = []
+    deps_paths = []
+    seen = []
+    all_libraries += vhdl_provider.libraries
+    for name, path in all_libraries:
+        if name != vhdl_provider.library_name and name not in seen:
+            flag_libraries += [
+                "--map={}:{}/{}".format(name, path.short_path, name)]
+            deps_paths += [path]
+            seen += [name]
+
+
+    work_library_file = get_single_file_from(ctx.attr.entity)
+
+    elaborate_provider = ctx.attr.entity[ElaborateProvider]
+
+    runfiles = ctx.runfiles(
+        files=[vhdl_provider.library_dir] + ctx.attr._script.files.to_list(),
+        transitive_files=depset(artifacts + deps_paths))
+
+    # Collect VPI plugins
+    vpi_plugins = vhdl_provider.vpi_plugins.to_list()
+    runfiles = runfiles.merge(ctx.runfiles(files = vpi_plugins))
+
+    # Construct --load= flags for VPI plugins
+    vpi_flags = ""
+    if vpi_plugins:
+        vpi_flags = "--load={}".format(",".join([p.short_path for p in vpi_plugins]))
+    
+    # Add user arguments
+    extra_args = " ".join(ctx.attr.args)
+
+    runfiles = runfiles.merge_all([ctx.attr._script[DefaultInfo].default_runfiles])
+    inputs = deps_paths + [vhdl_provider.library_dir] + ([std_lib_dir] if hasattr(std_lib_dir, "path") else []) + artifacts + vpi_plugins
+    i_runfiles = ctx.runfiles(files = inputs)
+
+    tools = [analyzer_x, ctx.executable._script, ] + artifacts
+    t_runfiles = ctx.runfiles(files = tools)
+
+    runfiles.merge_all([t_runfiles, i_runfiles, ctx.attr._script[DefaultInfo].default_runfiles])
+    
+    # Calculate the runfiles prefix path
+    # If the workspace is not _main (e.g. we are an external repo), we need to prefix the paths
+    nvc_lib_path_for_wrapper = nvc_lib_path
+    if nvc_lib_path.startswith("external/"):
+        nvc_lib_path_for_wrapper = "../" + nvc_lib_path[9:]
+
+    analyzer_for_wrapper = analyzer
+    if analyzer.startswith("external/"):
+        analyzer_for_wrapper = "../" + analyzer[9:]
+
+    base_dir_for_wrapper = base_dir
+    if base_dir.startswith("external/"):
+        base_dir_for_wrapper = "../" + base_dir[9:]
+
+    nvc_ld_library_path = get_nvc_ld_library_path(nvc_info, base_dir, ctx.configuration.default_shell_env)
+    nvc_ld_library_path_for_wrapper = ":".join([
+        ("../" + p[9:]) if p.startswith("external/") else p
+        for p in nvc_ld_library_path.split(":")
+    ])
+
+    ctx.actions.expand_template(
+        template = ctx.file._template,
+        output = ctx.outputs.executable,
+        substitutions = {
+            "{{EXECUTABLE}}": "NVC_LD_LIBRARY_PATH=\"" + nvc_ld_library_path_for_wrapper + "\" LD_LIBRARY_PATH=\"" + base_dir_for_wrapper + "/lib/x86_64-linux-gnu\" " + ctx.executable._script.short_path,
+            "{{VHDL_STANDARD}}": ctx.attr.standard,
+            "{{ANALYZER}}": analyzer_for_wrapper,
+            "{{LIBRARY_NAME}}": vhdl_provider.library_name,
+            "{{LIBRARY_PATHS}}": " ".join(flag_libraries + ["-L", nvc_lib_path_for_wrapper]),
+            "{{STDLIB_DIR}}": nvc_lib_path_for_wrapper[:-4],
+            "{{ENTITY}}": elaborate_provider.entity,
+            "{{LIB_DIR_IN_PATH}}": vhdl_provider.library_dir.short_path,
+            "{{LIB_DIR_OUT_PATH}}": work_library_file.short_path,
+            "{{WAVE_FILE}}": "{}.fst".format(ctx.attr.name),
+            "{{VPI_FLAGS}}": vpi_flags,
+            "{{EXTRA_ARGS}}": extra_args,
+        },
+    )
+    return [DefaultInfo(runfiles=runfiles)]
+
+_vhdl_internal_test = rule(
+    doc = "Internal rule to execute a VHDL test using NVC.",
+    test = True,
+    implementation = _nvc_vhdl_test,
+    attrs = {
+        "entity": attr.label(
+            doc = "The elaborated entity to test.",
+        ),
+        "deps": attr.label_list(
+            default = [],
+            doc = "Dependencies required for the test.",
+        ),
+        "_script": attr.label(
+            default = _NVC_WRAPPER,
+            executable = True,
+            cfg = "host",
+            doc = "Wrapper script to run NVC.",
+        ),
+        "standard": attr.string(
+            default = _VHDL_STANDARD_DEFAULT,
+            doc = "The VHDL standard to use (e.g., '2008', '2019').",
+        ),
+        "_template": attr.label(
+            default = Label("//build/nvc:unittest.tpl.sh"),
+            allow_single_file = True,
+            doc = "Template for the test execution script.",
+        ),
+    },
+    toolchains = [
+      _NVC_TOOLCHAIN_TYPE,
+    ],
+)
+
+def nvc_vhdl_test(name, srcs, deps,
+    standard=_VHDL_STANDARD_DEFAULT, args=[], entity=None, entities=[]):
+    """
+    Defines a VHDL test.
+
+    This macro combines `nvc_vhdl_library`, `nvc_vhdl_elaborate`, and internal test
+    execution steps into a single logical target.
+
+    Args:
+        name: The name of the base test target.
+        srcs: A list of VHDL source files (`.vhdl` or `.vhd`).
+        deps: A list of `nvc_vhdl_library` targets that this test depends on.
+        standard: The VHDL standard to use (e.g., "2008", "2019"). Defaults to "2019".
+        args: A list of additional command-line arguments to pass to the NVC simulator.
+        entity: A single entity to test.
+        entities: A list of entities to test. If both `entity` and `entities` are provided, all are tested.
+    """
+    entity_list = []
+    if entity:
+        entity_list += [entity]
+    entity_list += entities
+
+    for entity in entity_list:
+        # Strictly speaking this is not correct, since we're compiling the same
+        # library twice.
+        nvc_vhdl_library_name = "{name}_{entity}_lib".format(name=name,entity=entity)
+        nvc_vhdl_library(
+            name = nvc_vhdl_library_name,
+            srcs = srcs,
+            deps = deps,
+            standard = standard,
+        )
+        e = "{entity}".format(entity=entity)
+        nvc_vhdl_elaborate(
+            name = e,
+            library = ":{}".format(nvc_vhdl_library_name),
+            standard = standard,
+        )
+        _vhdl_internal_test(
+            name = "{name}_{entity}_test".format(name=name,entity=entity),
+            entity = ":{}".format(e),
+            args = args,
+            standard = standard,
+        )
+

--- a/internal/nvc_vhdl_test.md
+++ b/internal/nvc_vhdl_test.md
@@ -1,0 +1,34 @@
+<!-- Generated with Stardoc: http://skydoc.bazel.build -->
+
+
+
+<a id="nvc_vhdl_test"></a>
+
+## nvc_vhdl_test
+
+<pre>
+load("@rules_nvc//internal:nvc_vhdl_test.bzl", "nvc_vhdl_test")
+
+nvc_vhdl_test(<a href="#nvc_vhdl_test-name">name</a>, <a href="#nvc_vhdl_test-srcs">srcs</a>, <a href="#nvc_vhdl_test-deps">deps</a>, <a href="#nvc_vhdl_test-standard">standard</a>, <a href="#nvc_vhdl_test-args">args</a>, <a href="#nvc_vhdl_test-entity">entity</a>, <a href="#nvc_vhdl_test-entities">entities</a>)
+</pre>
+
+Defines a VHDL test.
+
+This macro combines `nvc_vhdl_library`, `nvc_vhdl_elaborate`, and internal test
+execution steps into a single logical target.
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="nvc_vhdl_test-name"></a>name |  The name of the base test target.   |  none |
+| <a id="nvc_vhdl_test-srcs"></a>srcs |  A list of VHDL source files (`.vhdl` or `.vhd`).   |  none |
+| <a id="nvc_vhdl_test-deps"></a>deps |  A list of `nvc_vhdl_library` targets that this test depends on.   |  none |
+| <a id="nvc_vhdl_test-standard"></a>standard |  The VHDL standard to use (e.g., "2008", "2019"). Defaults to "2019".   |  `"2019"` |
+| <a id="nvc_vhdl_test-args"></a>args |  A list of additional command-line arguments to pass to the NVC simulator.   |  `[]` |
+| <a id="nvc_vhdl_test-entity"></a>entity |  A single entity to test.   |  `None` |
+| <a id="nvc_vhdl_test-entities"></a>entities |  A list of entities to test. If both `entity` and `entities` are provided, all are tested.   |  `[]` |
+
+

--- a/internal/produce_waveform.bzl
+++ b/internal/produce_waveform.bzl
@@ -46,7 +46,7 @@ produce_waveform = rule(
         "simulation": attr.label(
             executable = True,
             cfg = "host",
-            doc = "The simulation target (`vhdl_run`) to execute.",
+            doc = "The simulation target (`nvc_vhdl_run`) to execute.",
         ),
         "data": attr.label_list(
             doc = "Data files required for the simulation.",

--- a/internal/produce_waveform.md
+++ b/internal/produce_waveform.md
@@ -22,7 +22,7 @@ Produces a waveform file (VCD) from a VHDL simulation run.
 | <a id="produce_waveform-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
 | <a id="produce_waveform-data"></a>data |  Data files required for the simulation.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="produce_waveform-args"></a>args |  Additional command-line arguments to pass to the simulation.   | List of strings | optional |  `[]`  |
-| <a id="produce_waveform-simulation"></a>simulation |  The simulation target (`vhdl_run`) to execute.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
+| <a id="produce_waveform-simulation"></a>simulation |  The simulation target (`nvc_vhdl_run`) to execute.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
 | <a id="produce_waveform-use_fst"></a>use_fst |  A boolean indicating whether to expect an FST file instead of VCD file. Defaults to `False`.   | Boolean | optional |  `False`  |
 
 

--- a/macros.bzl
+++ b/macros.bzl
@@ -1,20 +1,20 @@
-load("//build/nvc:rules.bzl", "vhdl_run", "vhdl_elaborate", "vhdl_library")
+load("//build/nvc:rules.bzl", "nvc_vhdl_run", "nvc_vhdl_elaborate", "nvc_vhdl_library")
 
-def vhdl_testbench(name, srcs, deps, entity=None, args=[]):
-    vhdl_library_name = "{}_lib".format(name)
-    vhdl_library(
-        name = vhdl_library_name,
+def nvc_vhdl_testbench(name, srcs, deps, entity=None, args=[]):
+    nvc_vhdl_library_name = "{}_lib".format(name)
+    nvc_vhdl_library(
+        name = nvc_vhdl_library_name,
         srcs = srcs,
         deps = deps,
     )
     e = "{}_tb".format(name)
     if entity:
         e = entity
-    vhdl_elaborate(
+    nvc_vhdl_elaborate(
         name = e,
-        library = ":{}".format(vhdl_library_name)
+        library = ":{}".format(nvc_vhdl_library_name)
     )
-    vhdl_run(
+    nvc_vhdl_run(
         name = name,
         entity = ":{}".format(e),
         args = args,

--- a/macros.md
+++ b/macros.md
@@ -2,14 +2,14 @@
 
 
 
-<a id="vhdl_testbench"></a>
+<a id="nvc_vhdl_testbench"></a>
 
-## vhdl_testbench
+## nvc_vhdl_testbench
 
 <pre>
-load("@rules_nvc//:macros.bzl", "vhdl_testbench")
+load("@rules_nvc//:macros.bzl", "nvc_vhdl_testbench")
 
-vhdl_testbench(<a href="#vhdl_testbench-name">name</a>, <a href="#vhdl_testbench-srcs">srcs</a>, <a href="#vhdl_testbench-deps">deps</a>, <a href="#vhdl_testbench-entity">entity</a>, <a href="#vhdl_testbench-args">args</a>)
+nvc_vhdl_testbench(<a href="#nvc_vhdl_testbench-name">name</a>, <a href="#nvc_vhdl_testbench-srcs">srcs</a>, <a href="#nvc_vhdl_testbench-deps">deps</a>, <a href="#nvc_vhdl_testbench-entity">entity</a>, <a href="#nvc_vhdl_testbench-args">args</a>)
 </pre>
 
 
@@ -19,10 +19,10 @@ vhdl_testbench(<a href="#vhdl_testbench-name">name</a>, <a href="#vhdl_testbench
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
-| <a id="vhdl_testbench-name"></a>name |  <p align="center"> - </p>   |  none |
-| <a id="vhdl_testbench-srcs"></a>srcs |  <p align="center"> - </p>   |  none |
-| <a id="vhdl_testbench-deps"></a>deps |  <p align="center"> - </p>   |  none |
-| <a id="vhdl_testbench-entity"></a>entity |  <p align="center"> - </p>   |  `None` |
-| <a id="vhdl_testbench-args"></a>args |  <p align="center"> - </p>   |  `[]` |
+| <a id="nvc_vhdl_testbench-name"></a>name |  <p align="center"> - </p>   |  none |
+| <a id="nvc_vhdl_testbench-srcs"></a>srcs |  <p align="center"> - </p>   |  none |
+| <a id="nvc_vhdl_testbench-deps"></a>deps |  <p align="center"> - </p>   |  none |
+| <a id="nvc_vhdl_testbench-entity"></a>entity |  <p align="center"> - </p>   |  `None` |
+| <a id="nvc_vhdl_testbench-args"></a>args |  <p align="center"> - </p>   |  `[]` |
 
 

--- a/nvc/BUILD.bazel
+++ b/nvc/BUILD.bazel
@@ -18,10 +18,10 @@ bzl_library(
         "//internal:providers",
         "//internal:toolchain",
         "//internal:utils",
-        "//internal:vhdl_elaborate",
-        "//internal:vhdl_library",
-        "//internal:vhdl_run",
-        "//internal:vhdl_test",
+        "//internal:nvc_vhdl_elaborate",
+        "//internal:nvc_vhdl_library",
+        "//internal:nvc_vhdl_run",
+        "//internal:nvc_vhdl_test",
     ],
 )
 

--- a/nvc/rules.bzl
+++ b/nvc/rules.bzl
@@ -7,12 +7,12 @@ load("//internal:toolchain.bzl",
     _nvc_toolchain = "nvc_toolchain")
 
 
-load("//internal:vhdl_library.bzl", _vhdl_library = "vhdl_library")
-load("//internal:vhdl_elaborate.bzl", _vhdl_elaborate = "vhdl_elaborate")
-load("//internal:vhdl_run.bzl", _vhdl_run = "vhdl_run")
+load("//internal:nvc_vhdl_library.bzl", _nvc_vhdl_library = "nvc_vhdl_library")
+load("//internal:nvc_vhdl_elaborate.bzl", _nvc_vhdl_elaborate = "nvc_vhdl_elaborate")
+load("//internal:nvc_vhdl_run.bzl", _nvc_vhdl_run = "nvc_vhdl_run")
 load("//internal:macros.bzl", _wave_view = "wave_view")
 load("//internal:produce_waveform.bzl", _produce_waveform = "produce_waveform")
-load("//internal:vhdl_test.bzl", _vhdl_test = "vhdl_test")
+load("//internal:nvc_vhdl_test.bzl", _nvc_vhdl_test = "nvc_vhdl_test")
 load("//internal:extract_file.bzl", _extract_file = "extract_file")
 
 
@@ -20,17 +20,17 @@ load("//internal:extract_file.bzl", _extract_file = "extract_file")
 
 nvc_toolchain = _nvc_toolchain
 
-vhdl_library = _vhdl_library
+nvc_vhdl_library = _nvc_vhdl_library
 
-vhdl_elaborate = _vhdl_elaborate
+nvc_vhdl_elaborate = _nvc_vhdl_elaborate
 
-vhdl_run = _vhdl_run
+nvc_vhdl_run = _nvc_vhdl_run
 
 produce_waveform = _produce_waveform
 
 extract_file = _extract_file
 
-vhdl_test = _vhdl_test
+nvc_vhdl_test = _nvc_vhdl_test
 
 # Macros
 

--- a/nvc/rules.md
+++ b/nvc/rules.md
@@ -47,6 +47,80 @@ Defines the NVC toolchain, linking to the NVC analyzer and standard library.
 | <a id="nvc_toolchain-artifacts_dir"></a>artifacts_dir |  The directory containing NVC standard libraries and artifacts.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
 
 
+<a id="nvc_vhdl_elaborate"></a>
+
+## nvc_vhdl_elaborate
+
+<pre>
+load("@rules_nvc//nvc:rules.bzl", "nvc_vhdl_elaborate")
+
+nvc_vhdl_elaborate(<a href="#nvc_vhdl_elaborate-name">name</a>, <a href="#nvc_vhdl_elaborate-library">library</a>, <a href="#nvc_vhdl_elaborate-standard">standard</a>)
+</pre>
+
+Elaborates a VHDL design using NVC.
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="nvc_vhdl_elaborate-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="nvc_vhdl_elaborate-library"></a>library |  The `nvc_vhdl_library` target to elaborate.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
+| <a id="nvc_vhdl_elaborate-standard"></a>standard |  The VHDL standard to use for elaboration (e.g., '2019').   | String | optional |  `"2019"`  |
+
+
+<a id="nvc_vhdl_library"></a>
+
+## nvc_vhdl_library
+
+<pre>
+load("@rules_nvc//nvc:rules.bzl", "nvc_vhdl_library")
+
+nvc_vhdl_library(<a href="#nvc_vhdl_library-name">name</a>, <a href="#nvc_vhdl_library-deps">deps</a>, <a href="#nvc_vhdl_library-srcs">srcs</a>, <a href="#nvc_vhdl_library-entities">entities</a>, <a href="#nvc_vhdl_library-library_name">library_name</a>, <a href="#nvc_vhdl_library-standard">standard</a>, <a href="#nvc_vhdl_library-vpi_plugins">vpi_plugins</a>)
+</pre>
+
+Compiles VHDL source files into a library using NVC.
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="nvc_vhdl_library-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="nvc_vhdl_library-deps"></a>deps |  A list of other `nvc_vhdl_library` targets that this library depends on.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="nvc_vhdl_library-srcs"></a>srcs |  A list of VHDL source files.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="nvc_vhdl_library-entities"></a>entities |  A list of VHDL entities provided by this library.   | List of strings | optional |  `[]`  |
+| <a id="nvc_vhdl_library-library_name"></a>library_name |  If the target name is not appropriate as a library name, provide one here   | String | optional |  `""`  |
+| <a id="nvc_vhdl_library-standard"></a>standard |  The VHDL standard to use for compilation (e.g., '2008', '2019'). Defaults to '2019'.   | String | optional |  `"2019"`  |
+| <a id="nvc_vhdl_library-vpi_plugins"></a>vpi_plugins |  List of VPI plugins required for simulation.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+
+
+<a id="nvc_vhdl_run"></a>
+
+## nvc_vhdl_run
+
+<pre>
+load("@rules_nvc//nvc:rules.bzl", "nvc_vhdl_run")
+
+nvc_vhdl_run(<a href="#nvc_vhdl_run-name">name</a>, <a href="#nvc_vhdl_run-deps">deps</a>, <a href="#nvc_vhdl_run-args">args</a>, <a href="#nvc_vhdl_run-entity">entity</a>, <a href="#nvc_vhdl_run-standard">standard</a>, <a href="#nvc_vhdl_run-use_fst">use_fst</a>, <a href="#nvc_vhdl_run-use_vcd">use_vcd</a>)
+</pre>
+
+Simulates an elaborated VHDL design using NVC.
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="nvc_vhdl_run-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="nvc_vhdl_run-deps"></a>deps |  A list of other `nvc_vhdl_library` targets that this simulation depends on.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="nvc_vhdl_run-args"></a>args |  A list of added command line args to use   | List of strings | optional |  `[]`  |
+| <a id="nvc_vhdl_run-entity"></a>entity |  The elaborated VHDL entity to simulate. This should be a `nvc_vhdl_elaborate` target.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
+| <a id="nvc_vhdl_run-standard"></a>standard |  The VHDL standard to use for simulation. Defaults to '2019'.   | String | optional |  `"2019"`  |
+| <a id="nvc_vhdl_run-use_fst"></a>use_fst |  A boolean indicating whether to generate a FST file for waveform viewing. Defaults to `False`. Takes precedence over `use_vcd`.   | Boolean | optional |  `False`  |
+| <a id="nvc_vhdl_run-use_vcd"></a>use_vcd |  A boolean indicating whether to generate a VCD (Value Change Dump) file for waveform viewing. Defaults to `True`.   | Boolean | optional |  `True`  |
+
+
 <a id="produce_waveform"></a>
 
 ## produce_waveform
@@ -67,97 +141,23 @@ Produces a waveform file (VCD) from a VHDL simulation run.
 | <a id="produce_waveform-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
 | <a id="produce_waveform-data"></a>data |  Data files required for the simulation.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="produce_waveform-args"></a>args |  Additional command-line arguments to pass to the simulation.   | List of strings | optional |  `[]`  |
-| <a id="produce_waveform-simulation"></a>simulation |  The simulation target (`vhdl_run`) to execute.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
+| <a id="produce_waveform-simulation"></a>simulation |  The simulation target (`nvc_vhdl_run`) to execute.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
 | <a id="produce_waveform-use_fst"></a>use_fst |  A boolean indicating whether to expect an FST file instead of VCD file. Defaults to `False`.   | Boolean | optional |  `False`  |
 
 
-<a id="vhdl_elaborate"></a>
+<a id="nvc_vhdl_test"></a>
 
-## vhdl_elaborate
-
-<pre>
-load("@rules_nvc//nvc:rules.bzl", "vhdl_elaborate")
-
-vhdl_elaborate(<a href="#vhdl_elaborate-name">name</a>, <a href="#vhdl_elaborate-library">library</a>, <a href="#vhdl_elaborate-standard">standard</a>)
-</pre>
-
-Elaborates a VHDL design using NVC.
-
-**ATTRIBUTES**
-
-
-| Name  | Description | Type | Mandatory | Default |
-| :------------- | :------------- | :------------- | :------------- | :------------- |
-| <a id="vhdl_elaborate-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
-| <a id="vhdl_elaborate-library"></a>library |  The `vhdl_library` target to elaborate.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
-| <a id="vhdl_elaborate-standard"></a>standard |  The VHDL standard to use for elaboration (e.g., '2019').   | String | optional |  `"2019"`  |
-
-
-<a id="vhdl_library"></a>
-
-## vhdl_library
+## nvc_vhdl_test
 
 <pre>
-load("@rules_nvc//nvc:rules.bzl", "vhdl_library")
+load("@rules_nvc//nvc:rules.bzl", "nvc_vhdl_test")
 
-vhdl_library(<a href="#vhdl_library-name">name</a>, <a href="#vhdl_library-deps">deps</a>, <a href="#vhdl_library-srcs">srcs</a>, <a href="#vhdl_library-entities">entities</a>, <a href="#vhdl_library-library_name">library_name</a>, <a href="#vhdl_library-standard">standard</a>, <a href="#vhdl_library-vpi_plugins">vpi_plugins</a>)
-</pre>
-
-Compiles VHDL source files into a library using NVC.
-
-**ATTRIBUTES**
-
-
-| Name  | Description | Type | Mandatory | Default |
-| :------------- | :------------- | :------------- | :------------- | :------------- |
-| <a id="vhdl_library-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
-| <a id="vhdl_library-deps"></a>deps |  A list of other `vhdl_library` targets that this library depends on.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
-| <a id="vhdl_library-srcs"></a>srcs |  A list of VHDL source files.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
-| <a id="vhdl_library-entities"></a>entities |  A list of VHDL entities provided by this library.   | List of strings | optional |  `[]`  |
-| <a id="vhdl_library-library_name"></a>library_name |  If the target name is not appropriate as a library name, provide one here   | String | optional |  `""`  |
-| <a id="vhdl_library-standard"></a>standard |  The VHDL standard to use for compilation (e.g., '2008', '2019'). Defaults to '2019'.   | String | optional |  `"2019"`  |
-| <a id="vhdl_library-vpi_plugins"></a>vpi_plugins |  List of VPI plugins required for simulation.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
-
-
-<a id="vhdl_run"></a>
-
-## vhdl_run
-
-<pre>
-load("@rules_nvc//nvc:rules.bzl", "vhdl_run")
-
-vhdl_run(<a href="#vhdl_run-name">name</a>, <a href="#vhdl_run-deps">deps</a>, <a href="#vhdl_run-args">args</a>, <a href="#vhdl_run-entity">entity</a>, <a href="#vhdl_run-standard">standard</a>, <a href="#vhdl_run-use_fst">use_fst</a>, <a href="#vhdl_run-use_vcd">use_vcd</a>)
-</pre>
-
-Simulates an elaborated VHDL design using NVC.
-
-**ATTRIBUTES**
-
-
-| Name  | Description | Type | Mandatory | Default |
-| :------------- | :------------- | :------------- | :------------- | :------------- |
-| <a id="vhdl_run-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
-| <a id="vhdl_run-deps"></a>deps |  A list of other `vhdl_library` targets that this simulation depends on.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
-| <a id="vhdl_run-args"></a>args |  A list of added command line args to use   | List of strings | optional |  `[]`  |
-| <a id="vhdl_run-entity"></a>entity |  The elaborated VHDL entity to simulate. This should be a `vhdl_elaborate` target.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
-| <a id="vhdl_run-standard"></a>standard |  The VHDL standard to use for simulation. Defaults to '2019'.   | String | optional |  `"2019"`  |
-| <a id="vhdl_run-use_fst"></a>use_fst |  A boolean indicating whether to generate a FST file for waveform viewing. Defaults to `False`. Takes precedence over `use_vcd`.   | Boolean | optional |  `False`  |
-| <a id="vhdl_run-use_vcd"></a>use_vcd |  A boolean indicating whether to generate a VCD (Value Change Dump) file for waveform viewing. Defaults to `True`.   | Boolean | optional |  `True`  |
-
-
-<a id="vhdl_test"></a>
-
-## vhdl_test
-
-<pre>
-load("@rules_nvc//nvc:rules.bzl", "vhdl_test")
-
-vhdl_test(<a href="#vhdl_test-name">name</a>, <a href="#vhdl_test-srcs">srcs</a>, <a href="#vhdl_test-deps">deps</a>, <a href="#vhdl_test-standard">standard</a>, <a href="#vhdl_test-args">args</a>, <a href="#vhdl_test-entity">entity</a>, <a href="#vhdl_test-entities">entities</a>)
+nvc_vhdl_test(<a href="#nvc_vhdl_test-name">name</a>, <a href="#nvc_vhdl_test-srcs">srcs</a>, <a href="#nvc_vhdl_test-deps">deps</a>, <a href="#nvc_vhdl_test-standard">standard</a>, <a href="#nvc_vhdl_test-args">args</a>, <a href="#nvc_vhdl_test-entity">entity</a>, <a href="#nvc_vhdl_test-entities">entities</a>)
 </pre>
 
 Defines a VHDL test.
 
-This macro combines `vhdl_library`, `vhdl_elaborate`, and internal test
+This macro combines `nvc_vhdl_library`, `nvc_vhdl_elaborate`, and internal test
 execution steps into a single logical target.
 
 
@@ -166,13 +166,13 @@ execution steps into a single logical target.
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
-| <a id="vhdl_test-name"></a>name |  The name of the base test target.   |  none |
-| <a id="vhdl_test-srcs"></a>srcs |  A list of VHDL source files (`.vhdl` or `.vhd`).   |  none |
-| <a id="vhdl_test-deps"></a>deps |  A list of `vhdl_library` targets that this test depends on.   |  none |
-| <a id="vhdl_test-standard"></a>standard |  The VHDL standard to use (e.g., "2008", "2019"). Defaults to "2019".   |  `"2019"` |
-| <a id="vhdl_test-args"></a>args |  A list of additional command-line arguments to pass to the NVC simulator.   |  `[]` |
-| <a id="vhdl_test-entity"></a>entity |  A single entity to test.   |  `None` |
-| <a id="vhdl_test-entities"></a>entities |  A list of entities to test. If both `entity` and `entities` are provided, all are tested.   |  `[]` |
+| <a id="nvc_vhdl_test-name"></a>name |  The name of the base test target.   |  none |
+| <a id="nvc_vhdl_test-srcs"></a>srcs |  A list of VHDL source files (`.vhdl` or `.vhd`).   |  none |
+| <a id="nvc_vhdl_test-deps"></a>deps |  A list of `nvc_vhdl_library` targets that this test depends on.   |  none |
+| <a id="nvc_vhdl_test-standard"></a>standard |  The VHDL standard to use (e.g., "2008", "2019"). Defaults to "2019".   |  `"2019"` |
+| <a id="nvc_vhdl_test-args"></a>args |  A list of additional command-line arguments to pass to the NVC simulator.   |  `[]` |
+| <a id="nvc_vhdl_test-entity"></a>entity |  A single entity to test.   |  `None` |
+| <a id="nvc_vhdl_test-entities"></a>entities |  A list of entities to test. If both `entity` and `entities` are provided, all are tested.   |  `[]` |
 
 
 <a id="wave_view"></a>
@@ -182,7 +182,7 @@ execution steps into a single logical target.
 <pre>
 load("@rules_nvc//nvc:rules.bzl", "wave_view")
 
-wave_view(<a href="#wave_view-name">name</a>, <a href="#wave_view-vhdl_run">vhdl_run</a>, <a href="#wave_view-args">args</a>, <a href="#wave_view-deps">deps</a>, <a href="#wave_view-viewer">viewer</a>, <a href="#wave_view-testonly">testonly</a>, <a href="#wave_view-save_file">save_file</a>)
+wave_view(<a href="#wave_view-name">name</a>, <a href="#wave_view-nvc_vhdl_run">nvc_vhdl_run</a>, <a href="#wave_view-args">args</a>, <a href="#wave_view-deps">deps</a>, <a href="#wave_view-viewer">viewer</a>, <a href="#wave_view-testonly">testonly</a>, <a href="#wave_view-save_file">save_file</a>)
 </pre>
 
 Generates a sh_binary viewer.
@@ -190,7 +190,7 @@ Generates a sh_binary viewer.
 # Args
 
 - name: the target name.
-- vhdl_run: the target name for the `vhdl_run` target to
+- nvc_vhdl_run: the target name for the `nvc_vhdl_run` target to
   use the output from.
 - args: any additional arguments to add to invoke the viewer.
 - viewer: the viewer to invoke. The viewer must be compatible
@@ -203,7 +203,7 @@ Generates a sh_binary viewer.
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
 | <a id="wave_view-name"></a>name |  <p align="center"> - </p>   |  none |
-| <a id="wave_view-vhdl_run"></a>vhdl_run |  <p align="center"> - </p>   |  none |
+| <a id="wave_view-nvc_vhdl_run"></a>nvc_vhdl_run |  <p align="center"> - </p>   |  none |
 | <a id="wave_view-args"></a>args |  <p align="center"> - </p>   |  `[]` |
 | <a id="wave_view-deps"></a>deps |  <p align="center"> - </p>   |  `[]` |
 | <a id="wave_view-viewer"></a>viewer |  <p align="center"> - </p>   |  `"gtkwave"` |


### PR DESCRIPTION
# Description

This PR introduces a major breaking change to integrate `rules_vhdl` library providers to replace custom filegroups and standardize all target names for VHDL and Verilog.

## Commits
* **feat(vhdl)!: integrate rules_vhdl and standardize rule names**
  * Integrated rules_vhdl library providers using a compilation aspect to replace the custom filegroups.
  * Renamed NVC rules to use standard prefixes: `nvc_vhdl_` for VHDL and `nvc_verilog_` for Verilog targets.

## Breaking Changes
Renamed all `nvc_*` or VHDL-specific rules to use the `nvc_vhdl_` prefix, and Verilog rules to use the `nvc_verilog_` prefix. Also integrated rules_vhdl library providers to replace the custom filegroups.

This pull request has been created by an automated coding assistant, with
human supervision.

Prompt: send pr, make sure that in the commit you mentione `BREAKING CHANGE: ` followed by the description of the change
