### PR TITLE
fix: resolve malformed tag-and-release workflow syntax

### DIFF
--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -72,13 +72,3 @@ jobs:
     secrets:
       BCR_PUBLISH_TOKEN: ${{ secrets.BCR_PUBLISH_TOKEN }}
 
-.zip"
-
-  publish:
-    needs: tag
-    uses: ./.github/workflows/publish.yml
-    with:
-      tag_name: ${{ needs.tag.outputs.tag_name }}
-    secrets:
-      BCR_PUBLISH_TOKEN: ${{ secrets.BCR_PUBLISH_TOKEN }}
-


### PR DESCRIPTION
This PR resolves the malformed syntax in the `.github/workflows/tag-and-release.yml` GitHub workflow file.

### Summary of commits:
- **fix: resolve malformed tag-and-release workflow syntax**: Removed a duplicate `publish:` job definition and a stray `.zip"` string at the end of `.github/workflows/tag-and-release.yml`.

---
This pull request has been created by an automated coding assistant, with
human supervision.

Prompt: send pr