### PR TITLE
docs: document nvc version constraint (custom registry, not BCR)

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -12,6 +12,15 @@ bazel_dep(name = "gotopt2", version = "2.7.1")
 # The NVC VHDL compiler and simulator, built from source as a hermetic Bazel
 # module (no LLVM, all third-party deps from the BCR). Provides @nvc//:nvc (the
 # compiler binary) and @nvc//:std (the bootstrapped VHDL standard libraries).
+#
+# WARNING: This version (1.22.0.bcr.0) is sourced from the CUSTOM registry
+# (filmil/bazel-registry), NOT from BCR. The BCR only has 1.21.0, which has a
+# structurally different stdlib layout incompatible with rules_nvc:
+#   - 1.22.0.bcr.0 (required): single `stdlib/` tree with std/, ieee/, nvc/ etc.
+#   - 1.21.0 (BCR, DO NOT USE): per-library dirs under `vhdl_libs/<name>/<lib>/`
+# The vhdl_library rule in //internal:vhdl_library passes @nvc//:std directly
+# as the -L path; 1.21.0's layout puts the library one level too deep and
+# causes "Fatal: required library STD not found". Do not downgrade to BCR versions.
 bazel_dep(name = "nvc", version = "1.22.0.bcr.0")
 
 # Carry the fix for nickg/nvc issue #1537 until it lands upstream and in the


### PR DESCRIPTION
## Summary

- Adds a detailed warning comment to the `nvc` `bazel_dep` in `MODULE.bazel` explaining why it must stay at `1.22.0.bcr.0` from the custom registry (`filmil/bazel-registry`) and must not be "upgraded" to `1.21.0` from BCR.
- Closes #95 which broke CI by downgrading nvc to the incompatible BCR version.

## Root cause (from #95)

The automated dep-update tool found `nvc 1.21.0` in BCR and treated it as an upgrade from `1.22.0.bcr.0`. The two versions have structurally incompatible stdlib outputs:

| Version | Source | stdlib layout |
|---------|--------|---------------|
| `1.22.0.bcr.0` | `filmil/bazel-registry` | Single `stdlib/` tree: `stdlib/std/`, `stdlib/ieee/`, `stdlib/nvc/`, … |
| `1.21.0` | BCR | Per-library dirs: `vhdl_libs/std/std/`, `vhdl_libs/ieee/ieee/`, … |

`//internal:vhdl_library` passes the `@nvc//:std` artifact path directly as the `-L` flag to nvc. With `1.22.0.bcr.0` this resolves to `stdlib/` (correct — nvc finds `std/`, `ieee/` inside). With `1.21.0` it resolves to `vhdl_libs/std/std/` (one level too deep), producing `Fatal: required library STD not found`.

## Test plan

- [ ] CI passes on this branch (no MODULE.bazel version change, just a comment)
- [ ] Future automated dep-update runs should see the warning and not touch this dep

This pull request has been created by an automated coding assistant, with
human supervision.

Prompt: fix https://github.com/filmil/bazel_rules_nvc/actions/runs/27894084875/job/82542528757, send PR