### PR TITLE
feat: add tags parameter to vhdl_test macro

### DIFF
--- a/build/nvc/rules.md
+++ b/build/nvc/rules.md
@@ -207,7 +207,7 @@ Simulates an elaborated VHDL design using NVC.
 <pre>
 load("@rules_nvc//build/nvc:rules.bzl", "vhdl_test")
 
-vhdl_test(<a href="#vhdl_test-name">name</a>, <a href="#vhdl_test-srcs">srcs</a>, <a href="#vhdl_test-deps">deps</a>, <a href="#vhdl_test-standard">standard</a>, <a href="#vhdl_test-args">args</a>, <a href="#vhdl_test-entity">entity</a>, <a href="#vhdl_test-entities">entities</a>)
+vhdl_test(<a href="#vhdl_test-name">name</a>, <a href="#vhdl_test-srcs">srcs</a>, <a href="#vhdl_test-deps">deps</a>, <a href="#vhdl_test-standard">standard</a>, <a href="#vhdl_test-args">args</a>, <a href="#vhdl_test-entity">entity</a>, <a href="#vhdl_test-entities">entities</a>, <a href="#vhdl_test-tags">tags</a>)
 </pre>
 
 Defines a VHDL test.
@@ -228,6 +228,7 @@ execution steps into a single logical target.
 | <a id="vhdl_test-args"></a>args |  A list of additional command-line arguments to pass to the NVC simulator.   |  `[]` |
 | <a id="vhdl_test-entity"></a>entity |  A single entity to test.   |  `None` |
 | <a id="vhdl_test-entities"></a>entities |  A list of entities to test. If both `entity` and `entities` are provided, all are tested.   |  `[]` |
+| <a id="vhdl_test-tags"></a>tags |  A list of tags to apply to the generated test target (e.g., ["manual"]).   |  `[]` |
 
 
 <a id="wave_view"></a>

--- a/internal/vhdl_test.bzl
+++ b/internal/vhdl_test.bzl
@@ -147,7 +147,7 @@ _vhdl_internal_test = rule(
 )
 
 def vhdl_test(name, srcs, deps,
-    standard=_VHDL_STANDARD_DEFAULT, args=[], entity=None, entities=[]):
+    standard=_VHDL_STANDARD_DEFAULT, args=[], entity=None, entities=[], tags=[]):
     """
     Defines a VHDL test.
 
@@ -162,6 +162,7 @@ def vhdl_test(name, srcs, deps,
         args: A list of additional command-line arguments to pass to the NVC simulator.
         entity: A single entity to test.
         entities: A list of entities to test. If both `entity` and `entities` are provided, all are tested.
+        tags: A list of tags to apply to the generated test target (e.g., ["manual"]).
     """
     entity_list = []
     if entity:
@@ -189,5 +190,6 @@ def vhdl_test(name, srcs, deps,
             entity = ":{}".format(e),
             args = args,
             standard = standard,
+            tags = tags,
         )
 

--- a/internal/vhdl_test.md
+++ b/internal/vhdl_test.md
@@ -9,7 +9,7 @@
 <pre>
 load("@rules_nvc//internal:vhdl_test.bzl", "vhdl_test")
 
-vhdl_test(<a href="#vhdl_test-name">name</a>, <a href="#vhdl_test-srcs">srcs</a>, <a href="#vhdl_test-deps">deps</a>, <a href="#vhdl_test-standard">standard</a>, <a href="#vhdl_test-args">args</a>, <a href="#vhdl_test-entity">entity</a>, <a href="#vhdl_test-entities">entities</a>)
+vhdl_test(<a href="#vhdl_test-name">name</a>, <a href="#vhdl_test-srcs">srcs</a>, <a href="#vhdl_test-deps">deps</a>, <a href="#vhdl_test-standard">standard</a>, <a href="#vhdl_test-args">args</a>, <a href="#vhdl_test-entity">entity</a>, <a href="#vhdl_test-entities">entities</a>, <a href="#vhdl_test-tags">tags</a>)
 </pre>
 
 Defines a VHDL test.
@@ -30,5 +30,6 @@ execution steps into a single logical target.
 | <a id="vhdl_test-args"></a>args |  A list of additional command-line arguments to pass to the NVC simulator.   |  `[]` |
 | <a id="vhdl_test-entity"></a>entity |  A single entity to test.   |  `None` |
 | <a id="vhdl_test-entities"></a>entities |  A list of entities to test. If both `entity` and `entities` are provided, all are tested.   |  `[]` |
+| <a id="vhdl_test-tags"></a>tags |  A list of tags to apply to the generated test target (e.g., ["manual"]).   |  `[]` |
 
 

--- a/nvc/rules.md
+++ b/nvc/rules.md
@@ -152,7 +152,7 @@ Simulates an elaborated VHDL design using NVC.
 <pre>
 load("@rules_nvc//nvc:rules.bzl", "vhdl_test")
 
-vhdl_test(<a href="#vhdl_test-name">name</a>, <a href="#vhdl_test-srcs">srcs</a>, <a href="#vhdl_test-deps">deps</a>, <a href="#vhdl_test-standard">standard</a>, <a href="#vhdl_test-args">args</a>, <a href="#vhdl_test-entity">entity</a>, <a href="#vhdl_test-entities">entities</a>)
+vhdl_test(<a href="#vhdl_test-name">name</a>, <a href="#vhdl_test-srcs">srcs</a>, <a href="#vhdl_test-deps">deps</a>, <a href="#vhdl_test-standard">standard</a>, <a href="#vhdl_test-args">args</a>, <a href="#vhdl_test-entity">entity</a>, <a href="#vhdl_test-entities">entities</a>, <a href="#vhdl_test-tags">tags</a>)
 </pre>
 
 Defines a VHDL test.
@@ -173,6 +173,7 @@ execution steps into a single logical target.
 | <a id="vhdl_test-args"></a>args |  A list of additional command-line arguments to pass to the NVC simulator.   |  `[]` |
 | <a id="vhdl_test-entity"></a>entity |  A single entity to test.   |  `None` |
 | <a id="vhdl_test-entities"></a>entities |  A list of entities to test. If both `entity` and `entities` are provided, all are tested.   |  `[]` |
+| <a id="vhdl_test-tags"></a>tags |  A list of tags to apply to the generated test target (e.g., ["manual"]).   |  `[]` |
 
 
 <a id="wave_view"></a>


### PR DESCRIPTION
## Summary

- Adds a `tags` parameter to `vhdl_test` in `internal/vhdl_test.bzl` and forwards it to the generated `_vhdl_internal_test` rule.
- Enables callers to use standard Bazel tags such as `"manual"` to exclude a test from wildcard `bazel test //...` runs.

## Changes

`internal/vhdl_test.bzl`: added `tags=[]` to the macro signature and `tags = tags` to the `_vhdl_internal_test(...)` call.

## Test plan

- [ ] CI passes (no functional change to existing tests — empty `tags` is the default)
- [ ] Manual verification: a `vhdl_test(..., tags = ["manual"])` no longer errors and is excluded from `bazel test //...`

Fixes #98.

This pull request has been created by an automated coding assistant, with
human supervision.

Prompt: fix https://github.com/filmil/bazel_rules_nvc/issues/98