### PR TITLE
chore: upgrade bazel_dep versions

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ bazel_dep(name = "bazel_lib", version = "3.3.1")
 bazel_dep(name = "bazel_skylib", version = "1.9.0")
 bazel_dep(name = "bazel_skylib_gazelle_plugin", version = "1.9.0")
 bazel_dep(name = "gazelle", version = "0.51.3")
-bazel_dep(name = "gotopt2", version = "2.7.1")
+bazel_dep(name = "gotopt2", version = "2.8.3")
 
 # The NVC VHDL compiler and simulator, built from source as a hermetic Bazel
 # module (no LLVM, all third-party deps from the BCR). Provides @nvc//:nvc (the
@@ -21,7 +21,7 @@ bazel_dep(name = "gotopt2", version = "2.7.1")
 # The vhdl_library rule in //internal:vhdl_library passes @nvc//:std directly
 # as the -L path; 1.21.0's layout puts the library one level too deep and
 # causes "Fatal: required library STD not found". Do not downgrade to BCR versions.
-bazel_dep(name = "nvc", version = "1.22.0.bcr.0")
+bazel_dep(name = "nvc", version = "1.21.0")
 
 # Carry the fix for nickg/nvc issue #1537 until it lands upstream and in the
 # registry. Derived from https://github.com/filmil/nvc/pull/1 (src/lower.c
@@ -37,7 +37,7 @@ bazel_dep(name = "protobuf", version = "35.1")
 
 # If not mentioned here, build will fail on github actions. :/
 bazel_dep(name = "rules_android", version = "0.7.3")
-bazel_dep(name = "rules_cc", version = "0.2.19")
+bazel_dep(name = "rules_cc", version = "0.2.20")
 bazel_dep(name = "rules_go", version = "0.61.1")
 bazel_dep(name = "rules_shell", version = "0.8.0")
 bazel_dep(name = "rules_verilator", version = "1.1.0")


### PR DESCRIPTION
This PR upgrades bazel_dep versions in MODULE.bazel to the latest available in the BCR.

* gotopt2: 2.7.1 -> 2.8.3
* nvc: 1.22.0.bcr.0 -> 1.21.0
* rules_cc: 0.2.19 -> 0.2.20