### PR TITLE
Add generics map + data to vhdl_test (elaboration-time firmware) — fixes #101

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -114,8 +114,8 @@
     "https://bcr.bazel.build/modules/googletest/1.15.2/MODULE.bazel": "6de1edc1d26cafb0ea1a6ab3f4d4192d91a312fd2d360b63adaa213cd00b2108",
     "https://bcr.bazel.build/modules/googletest/1.17.0/MODULE.bazel": "dbec758171594a705933a29fcf69293d2468c49ec1f2ebca65c36f504d72df46",
     "https://bcr.bazel.build/modules/googletest/1.17.0/source.json": "38e4454b25fc30f15439c0378e57909ab1fd0a443158aa35aec685da727cd713",
-    "https://bcr.bazel.build/modules/helly25_bzl/0.3.1/MODULE.bazel": "3a4be20f6fc13be32ad44643b8252ef5af09eee936f1d943cd4fd7867fa92826",
-    "https://bcr.bazel.build/modules/helly25_bzl/0.3.1/source.json": "b129ab1828492de2c163785bbeb4065c166de52d932524b4317beb5b7f917994",
+    "https://bcr.bazel.build/modules/helly25_bzl/0.4.3/MODULE.bazel": "9c20052fd3f1fb767c48b78c1bbc46f501a4ca69d14558429d1234e68e449f68",
+    "https://bcr.bazel.build/modules/helly25_bzl/0.4.3/source.json": "e8c54d81e72633fb6f1d23c7e2d44e0b39b1caef2a256141136a2f63e6204b78",
     "https://bcr.bazel.build/modules/jq.bzl/0.1.0/MODULE.bazel": "2ce69b1af49952cd4121a9c3055faa679e748ce774c7f1fda9657f936cae902f",
     "https://bcr.bazel.build/modules/jq.bzl/0.1.0/source.json": "746bf13cac0860f091df5e4911d0c593971cd8796b5ad4e809b2f8e133eee3d5",
     "https://bcr.bazel.build/modules/jsoncpp/1.9.5/MODULE.bazel": "31271aedc59e815656f5736f282bb7509a97c7ecb43e927ac1a37966e0578075",
@@ -165,7 +165,8 @@
     "https://bcr.bazel.build/modules/protobuf/33.1/MODULE.bazel": "982c8a0cceab4d790076f72b7677faf836b0dfadc2b66a34aab7232116c4ae39",
     "https://bcr.bazel.build/modules/protobuf/33.4/MODULE.bazel": "114775b816b38b6d0ca620450d6b02550c60ceedfdc8d9a229833b34a223dc42",
     "https://bcr.bazel.build/modules/protobuf/35.0/MODULE.bazel": "ee97170c013d94c366bbb5fe8a97b0650477cbc00e5e0f6a2c297484bc34d81b",
-    "https://bcr.bazel.build/modules/protobuf/35.0/source.json": "2162e80adef862606ba85ae42e0df85eb519376fd6ab49caddee6fb776a1281e",
+    "https://bcr.bazel.build/modules/protobuf/35.1/MODULE.bazel": "9f25044d646c9c1b1e03b25aa3818bf5250078eabadbd213ea940262dba99471",
+    "https://bcr.bazel.build/modules/protobuf/35.1/source.json": "5e256f85483431bd96fc9a6ae468e420326673e9d9f250d313725875597bf1ba",
     "https://bcr.bazel.build/modules/pybind11_bazel/2.11.1/MODULE.bazel": "88af1c246226d87e65be78ed49ecd1e6f5e98648558c14ce99176da041dc378e",
     "https://bcr.bazel.build/modules/pybind11_bazel/2.12.0/MODULE.bazel": "e6f4c20442eaa7c90d7190d8dc539d0ab422f95c65a57cc59562170c58ae3d34",
     "https://bcr.bazel.build/modules/pybind11_bazel/2.12.0/source.json": "6900fdc8a9e95866b8c0d4ad4aba4d4236317b5c1cd04c502df3f0d33afed680",
@@ -305,8 +306,8 @@
     "https://bcr.bazel.build/modules/rules_verilator/1.1.0/MODULE.bazel": "894635345a219e04a94493965d64fd7bcea6394a95d0eed0c724e582643bf78a",
     "https://bcr.bazel.build/modules/rules_verilator/1.1.0/source.json": "b108d13972aa4b56163b693a25ff6ba0a5e5a10eb921da6c71a904a7bf721a33",
     "https://bcr.bazel.build/modules/rules_verilog/1.1.0/MODULE.bazel": "7b1d2d0321566572b61b76a4b4c263ce4da27ee0437552e1c70cff838101db57",
-    "https://bcr.bazel.build/modules/rules_verilog/1.1.1/MODULE.bazel": "adcccf08f92e16936d6aa2e872f31a79e80712333be604de750d4b109fae1519",
-    "https://bcr.bazel.build/modules/rules_verilog/1.1.1/source.json": "32a02fe6f97e1a233cff48e0eae70243e2e25d4c57fc684f933e06ef67440d8b",
+    "https://bcr.bazel.build/modules/rules_verilog/1.2.0/MODULE.bazel": "6e87d9b2a9f7232d9967ad936de06a198414e7efe9485cc6186485720836ed29",
+    "https://bcr.bazel.build/modules/rules_verilog/1.2.0/source.json": "34270ce5ba7ceb88a1ebb15e39a3bd57084012b1997ef3f367f65447677af8b9",
     "https://bcr.bazel.build/modules/stardoc/0.5.1/MODULE.bazel": "1a05d92974d0c122f5ccf09291442580317cdd859f07a8655f1db9a60374f9f8",
     "https://bcr.bazel.build/modules/stardoc/0.5.3/MODULE.bazel": "c7f6948dae6999bf0db32c1858ae345f112cacf98f174c7a8bb707e41b974f1c",
     "https://bcr.bazel.build/modules/stardoc/0.6.2/MODULE.bazel": "7060193196395f5dd668eda046ccbeacebfd98efc77fed418dbe2b82ffaa39fd",
@@ -321,8 +322,8 @@
     "https://bcr.bazel.build/modules/tar.bzl/0.2.1/MODULE.bazel": "52d1c00a80a8cc67acbd01649e83d8dd6a9dc426a6c0b754a04fe8c219c76468",
     "https://bcr.bazel.build/modules/tar.bzl/0.6.0/MODULE.bazel": "a3584b4edcfafcabd9b0ef9819808f05b372957bbdff41601429d5fd0aac2e7c",
     "https://bcr.bazel.build/modules/tar.bzl/0.6.0/source.json": "4a620381df075a16cb3a7ed57bd1d05f7480222394c64a20fa51bdb636fda658",
-    "https://bcr.bazel.build/modules/toolchains_llvm/1.7.0/MODULE.bazel": "55aca6a8c5b372651f663c5e22faf3664d81165e40074c98fb8a30ee5af83272",
-    "https://bcr.bazel.build/modules/toolchains_llvm/1.7.0/source.json": "cda5fa1abeab5561e811860222952f6cb9373f34b88c5b3f4417459dca057a6d",
+    "https://bcr.bazel.build/modules/toolchains_llvm/1.8.0/MODULE.bazel": "68259b66e5fb84f94fa37125ad476c3eb8edf602a34bf58377cde9a16dd8fa98",
+    "https://bcr.bazel.build/modules/toolchains_llvm/1.8.0/source.json": "70d80fe5b626a3fadf812af41dda4a028640a1184f5a3c7e6cb20130d93ed783",
     "https://bcr.bazel.build/modules/upb/0.0.0-20220923-a547704/MODULE.bazel": "7298990c00040a0e2f121f6c32544bab27d4452f80d9ce51349b1a28f3005c43",
     "https://bcr.bazel.build/modules/upb/0.0.0-20230516-61a97ef/MODULE.bazel": "c0df5e35ad55e264160417fd0875932ee3c9dda63d9fccace35ac62f45e1b6f9",
     "https://bcr.bazel.build/modules/verilator/5.046.bcr.3/MODULE.bazel": "f3feea38d58189240e690dd849d430d66959454a2a73b0181a7ea671719f3022",
@@ -438,7 +439,7 @@
     "https://raw.githubusercontent.com/filmil/bazel-registry/main/modules/googletest/1.17.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/filmil/bazel-registry/main/modules/gotopt2/2.7.1/MODULE.bazel": "94e1ec81dc6f1764aeb12daa30f89c1664f32dde307fee407ef115ea6739d747",
     "https://raw.githubusercontent.com/filmil/bazel-registry/main/modules/gotopt2/2.7.1/source.json": "8b4cecd6e4c24a4009d657b8f663cd442903a0c1fb4a34a5285cff1e9ba169a4",
-    "https://raw.githubusercontent.com/filmil/bazel-registry/main/modules/helly25_bzl/0.3.1/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/filmil/bazel-registry/main/modules/helly25_bzl/0.4.3/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/filmil/bazel-registry/main/modules/jq.bzl/0.1.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/filmil/bazel-registry/main/modules/jsoncpp/1.9.5/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/filmil/bazel-registry/main/modules/jsoncpp/1.9.6.bcr.2/MODULE.bazel": "not found",
@@ -483,6 +484,7 @@
     "https://raw.githubusercontent.com/filmil/bazel-registry/main/modules/protobuf/33.1/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/filmil/bazel-registry/main/modules/protobuf/33.4/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/filmil/bazel-registry/main/modules/protobuf/35.0/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/filmil/bazel-registry/main/modules/protobuf/35.1/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/filmil/bazel-registry/main/modules/pybind11_bazel/2.11.1/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/filmil/bazel-registry/main/modules/pybind11_bazel/2.12.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/filmil/bazel-registry/main/modules/re2/2023-09-01/MODULE.bazel": "not found",
@@ -600,7 +602,7 @@
     "https://raw.githubusercontent.com/filmil/bazel-registry/main/modules/rules_venv/0.15.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/filmil/bazel-registry/main/modules/rules_verilator/1.1.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/filmil/bazel-registry/main/modules/rules_verilog/1.1.0/MODULE.bazel": "not found",
-    "https://raw.githubusercontent.com/filmil/bazel-registry/main/modules/rules_verilog/1.1.1/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/filmil/bazel-registry/main/modules/rules_verilog/1.2.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/filmil/bazel-registry/main/modules/stardoc/0.5.1/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/filmil/bazel-registry/main/modules/stardoc/0.5.3/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/filmil/bazel-registry/main/modules/stardoc/0.6.2/MODULE.bazel": "not found",
@@ -612,7 +614,7 @@
     "https://raw.githubusercontent.com/filmil/bazel-registry/main/modules/systemc/3.0.2/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/filmil/bazel-registry/main/modules/tar.bzl/0.2.1/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/filmil/bazel-registry/main/modules/tar.bzl/0.6.0/MODULE.bazel": "not found",
-    "https://raw.githubusercontent.com/filmil/bazel-registry/main/modules/toolchains_llvm/1.7.0/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/filmil/bazel-registry/main/modules/toolchains_llvm/1.8.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/filmil/bazel-registry/main/modules/upb/0.0.0-20220923-a547704/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/filmil/bazel-registry/main/modules/upb/0.0.0-20230516-61a97ef/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/filmil/bazel-registry/main/modules/verilator/5.046.bcr.3/MODULE.bazel": "not found",
@@ -1377,6 +1379,26 @@
           "explicitRootModuleDirectDevDeps": [],
           "useAllRepos": "NO",
           "reproducible": false
+        }
+      }
+    },
+    "@@toolchains_llvm+//toolchain/extensions:distributions.bzl%llvm_distributions": {
+      "general": {
+        "bzlTransitiveDigest": "gCdXpBt3HBBc280OILOFheHmO7lXWXJYnPgYiTtyapI=",
+        "usagesDigest": "VyKGZSw79ryPJ9gt0sqBfIkA7qGOU6tnlDHd7awkb6Q=",
+        "recordedInputs": [],
+        "generatedRepoSpecs": {
+          "llvm_distributions_data": {
+            "repoRuleId": "@@toolchains_llvm+//toolchain/internal:distributions_repo.bzl%llvm_distributions_repo",
+            "attributes": {
+              "srcs": [
+                "@@toolchains_llvm+//toolchain/distributions:pre_github.jsonc",
+                "@@toolchains_llvm+//toolchain/distributions:github_legacy.jsonc",
+                "@@toolchains_llvm+//toolchain/distributions:github.jsonc",
+                "@@toolchains_llvm+//toolchain/distributions:extra.jsonc"
+              ]
+            }
+          }
         }
       }
     }

--- a/build/nvc/rules.md
+++ b/build/nvc/rules.md
@@ -133,7 +133,7 @@ Compiles Verilog source files into a library using NVC.
 <pre>
 load("@rules_nvc//build/nvc:rules.bzl", "vhdl_elaborate")
 
-vhdl_elaborate(<a href="#vhdl_elaborate-name">name</a>, <a href="#vhdl_elaborate-library">library</a>, <a href="#vhdl_elaborate-standard">standard</a>)
+vhdl_elaborate(<a href="#vhdl_elaborate-name">name</a>, <a href="#vhdl_elaborate-data">data</a>, <a href="#vhdl_elaborate-generics">generics</a>, <a href="#vhdl_elaborate-library">library</a>, <a href="#vhdl_elaborate-standard">standard</a>)
 </pre>
 
 Elaborates a VHDL design using NVC.
@@ -144,6 +144,8 @@ Elaborates a VHDL design using NVC.
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="vhdl_elaborate-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="vhdl_elaborate-data"></a>data |  Files made available to the elaboration action, e.g. memory init files referenced by a generic value.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="vhdl_elaborate-generics"></a>generics |  Top-level VHDL generics to set at elaboration, as a name -> value map (emitted as -gNAME=VALUE after the top unit).  Values undergo $(location)/$(rootpath) expansion over `data`.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
 | <a id="vhdl_elaborate-library"></a>library |  The `vhdl_library` target to elaborate.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
 | <a id="vhdl_elaborate-standard"></a>standard |  The VHDL standard to use for elaboration (e.g., '2019').   | String | optional |  `"2019"`  |
 
@@ -207,7 +209,7 @@ Simulates an elaborated VHDL design using NVC.
 <pre>
 load("@rules_nvc//build/nvc:rules.bzl", "vhdl_test")
 
-vhdl_test(<a href="#vhdl_test-name">name</a>, <a href="#vhdl_test-srcs">srcs</a>, <a href="#vhdl_test-deps">deps</a>, <a href="#vhdl_test-standard">standard</a>, <a href="#vhdl_test-args">args</a>, <a href="#vhdl_test-entity">entity</a>, <a href="#vhdl_test-entities">entities</a>, <a href="#vhdl_test-tags">tags</a>)
+vhdl_test(<a href="#vhdl_test-name">name</a>, <a href="#vhdl_test-srcs">srcs</a>, <a href="#vhdl_test-deps">deps</a>, <a href="#vhdl_test-standard">standard</a>, <a href="#vhdl_test-args">args</a>, <a href="#vhdl_test-generics">generics</a>, <a href="#vhdl_test-data">data</a>, <a href="#vhdl_test-entity">entity</a>, <a href="#vhdl_test-entities">entities</a>, <a href="#vhdl_test-tags">tags</a>)
 </pre>
 
 Defines a VHDL test.
@@ -226,6 +228,8 @@ execution steps into a single logical target.
 | <a id="vhdl_test-deps"></a>deps |  A list of `vhdl_library` targets that this test depends on.   |  none |
 | <a id="vhdl_test-standard"></a>standard |  The VHDL standard to use (e.g., "2008", "2019"). Defaults to "2019".   |  `"2019"` |
 | <a id="vhdl_test-args"></a>args |  A list of additional command-line arguments to pass to the NVC simulator.   |  `[]` |
+| <a id="vhdl_test-generics"></a>generics |  Top-level VHDL generics to set at elaboration, as a name -> value map (emitted as -gNAME=VALUE). Values undergo $(location)/$(rootpath) expansion over `data`, so a generic can reference a build artifact (e.g. a memory init file the testbench reads at elaboration time).   |  `{}` |
+| <a id="vhdl_test-data"></a>data |  Files made available to the elaboration action (e.g. the memory init files referenced by `generics`).   |  `[]` |
 | <a id="vhdl_test-entity"></a>entity |  A single entity to test.   |  `None` |
 | <a id="vhdl_test-entities"></a>entities |  A list of entities to test. If both `entity` and `entities` are provided, all are tested.   |  `[]` |
 | <a id="vhdl_test-tags"></a>tags |  A list of tags to apply to the generated test target (e.g., ["manual"]).   |  `[]` |

--- a/internal/vhdl_elaborate.bzl
+++ b/internal/vhdl_elaborate.bzl
@@ -51,9 +51,19 @@ def _vhdl_elaborate(ctx):
         for p in vpi_plugins:
             vpi_flags.append("--load=" + p.path)
 
+    # Top-level generics set at elaboration (-gNAME=VALUE, placed after the top
+    # unit name).  Values undergo $(location)/$(rootpath) expansion over `data`,
+    # so a generic can point at a build artifact -- e.g. a memory init file that
+    # the testbench reads in a signal initializer at elaboration time.
+    data_files = ctx.files.data
+    generic_args = [
+        "-g{}={}".format(k, ctx.expand_location(v, targets = ctx.attr.data))
+        for k, v in ctx.attr.generics.items()
+    ]
+
     ctx.actions.run(
         outputs = [out_dir],
-        inputs = depset(direct = [vhdl_provider.library_dir] + ([std_lib_dir] if hasattr(std_lib_dir, "path") else []) + artifacts + nvc_deps + deps_paths + vpi_plugins).to_list(),
+        inputs = depset(direct = [vhdl_provider.library_dir] + ([std_lib_dir] if hasattr(std_lib_dir, "path") else []) + artifacts + nvc_deps + deps_paths + vpi_plugins + data_files).to_list(),
         executable = ctx.executable._script.path,
         env = {
             "NVC_LD_LIBRARY_PATH": get_nvc_ld_library_path(nvc_info, base_dir, ctx.configuration.default_shell_env),
@@ -68,7 +78,7 @@ def _vhdl_elaborate(ctx):
             "--library-dir-in-path={}".format(work_library_file.path),
             "--library-dir-out-path={}".format(out_dir.path),
             "--",
-        ] + vpi_flags,
+        ] + vpi_flags + generic_args,
         tools = [analyzer_x, ctx.executable._script] + artifacts,
         # Only seems to work from bazel 6.0.0 on.
         #toolchain = _NVC_TOOLCHAIN_TYPE,
@@ -106,6 +116,19 @@ vhdl_elaborate = rule(
         "standard": attr.string(
             default = _VHDL_STANDARD_DEFAULT,
             doc = "The VHDL standard to use for elaboration (e.g., '2019').",
+        ),
+        "generics": attr.string_dict(
+            default = {},
+            doc = "Top-level VHDL generics to set at elaboration, as a " +
+                  "name -> value map (emitted as -gNAME=VALUE after the top " +
+                  "unit).  Values undergo $(location)/$(rootpath) expansion " +
+                  "over `data`.",
+        ),
+        "data": attr.label_list(
+            allow_files = True,
+            default = [],
+            doc = "Files made available to the elaboration action, e.g. memory " +
+                  "init files referenced by a generic value.",
         ),
     },
     toolchains = [

--- a/internal/vhdl_elaborate.md
+++ b/internal/vhdl_elaborate.md
@@ -9,7 +9,7 @@
 <pre>
 load("@rules_nvc//internal:vhdl_elaborate.bzl", "vhdl_elaborate")
 
-vhdl_elaborate(<a href="#vhdl_elaborate-name">name</a>, <a href="#vhdl_elaborate-library">library</a>, <a href="#vhdl_elaborate-standard">standard</a>)
+vhdl_elaborate(<a href="#vhdl_elaborate-name">name</a>, <a href="#vhdl_elaborate-data">data</a>, <a href="#vhdl_elaborate-generics">generics</a>, <a href="#vhdl_elaborate-library">library</a>, <a href="#vhdl_elaborate-standard">standard</a>)
 </pre>
 
 Elaborates a VHDL design using NVC.
@@ -20,6 +20,8 @@ Elaborates a VHDL design using NVC.
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="vhdl_elaborate-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="vhdl_elaborate-data"></a>data |  Files made available to the elaboration action, e.g. memory init files referenced by a generic value.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="vhdl_elaborate-generics"></a>generics |  Top-level VHDL generics to set at elaboration, as a name -> value map (emitted as -gNAME=VALUE after the top unit).  Values undergo $(location)/$(rootpath) expansion over `data`.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
 | <a id="vhdl_elaborate-library"></a>library |  The `vhdl_library` target to elaborate.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
 | <a id="vhdl_elaborate-standard"></a>standard |  The VHDL standard to use for elaboration (e.g., '2019').   | String | optional |  `"2019"`  |
 

--- a/internal/vhdl_test.bzl
+++ b/internal/vhdl_test.bzl
@@ -147,7 +147,8 @@ _vhdl_internal_test = rule(
 )
 
 def vhdl_test(name, srcs, deps,
-    standard=_VHDL_STANDARD_DEFAULT, args=[], entity=None, entities=[], tags=[]):
+    standard=_VHDL_STANDARD_DEFAULT, args=[], generics={}, data=[],
+    entity=None, entities=[], tags=[]):
     """
     Defines a VHDL test.
 
@@ -160,6 +161,12 @@ def vhdl_test(name, srcs, deps,
         deps: A list of `vhdl_library` targets that this test depends on.
         standard: The VHDL standard to use (e.g., "2008", "2019"). Defaults to "2019".
         args: A list of additional command-line arguments to pass to the NVC simulator.
+        generics: Top-level VHDL generics to set at elaboration, as a name -> value
+            map (emitted as -gNAME=VALUE). Values undergo $(location)/$(rootpath)
+            expansion over `data`, so a generic can reference a build artifact
+            (e.g. a memory init file the testbench reads at elaboration time).
+        data: Files made available to the elaboration action (e.g. the memory init
+            files referenced by `generics`).
         entity: A single entity to test.
         entities: A list of entities to test. If both `entity` and `entities` are provided, all are tested.
         tags: A list of tags to apply to the generated test target (e.g., ["manual"]).
@@ -184,6 +191,8 @@ def vhdl_test(name, srcs, deps,
             name = e,
             library = ":{}".format(vhdl_library_name),
             standard = standard,
+            generics = generics,
+            data = data,
         )
         _vhdl_internal_test(
             name = "{name}_{entity}_test".format(name=name,entity=entity),

--- a/internal/vhdl_test.md
+++ b/internal/vhdl_test.md
@@ -9,7 +9,7 @@
 <pre>
 load("@rules_nvc//internal:vhdl_test.bzl", "vhdl_test")
 
-vhdl_test(<a href="#vhdl_test-name">name</a>, <a href="#vhdl_test-srcs">srcs</a>, <a href="#vhdl_test-deps">deps</a>, <a href="#vhdl_test-standard">standard</a>, <a href="#vhdl_test-args">args</a>, <a href="#vhdl_test-entity">entity</a>, <a href="#vhdl_test-entities">entities</a>, <a href="#vhdl_test-tags">tags</a>)
+vhdl_test(<a href="#vhdl_test-name">name</a>, <a href="#vhdl_test-srcs">srcs</a>, <a href="#vhdl_test-deps">deps</a>, <a href="#vhdl_test-standard">standard</a>, <a href="#vhdl_test-args">args</a>, <a href="#vhdl_test-generics">generics</a>, <a href="#vhdl_test-data">data</a>, <a href="#vhdl_test-entity">entity</a>, <a href="#vhdl_test-entities">entities</a>, <a href="#vhdl_test-tags">tags</a>)
 </pre>
 
 Defines a VHDL test.
@@ -28,6 +28,8 @@ execution steps into a single logical target.
 | <a id="vhdl_test-deps"></a>deps |  A list of `vhdl_library` targets that this test depends on.   |  none |
 | <a id="vhdl_test-standard"></a>standard |  The VHDL standard to use (e.g., "2008", "2019"). Defaults to "2019".   |  `"2019"` |
 | <a id="vhdl_test-args"></a>args |  A list of additional command-line arguments to pass to the NVC simulator.   |  `[]` |
+| <a id="vhdl_test-generics"></a>generics |  Top-level VHDL generics to set at elaboration, as a name -> value map (emitted as -gNAME=VALUE). Values undergo $(location)/$(rootpath) expansion over `data`, so a generic can reference a build artifact (e.g. a memory init file the testbench reads at elaboration time).   |  `{}` |
+| <a id="vhdl_test-data"></a>data |  Files made available to the elaboration action (e.g. the memory init files referenced by `generics`).   |  `[]` |
 | <a id="vhdl_test-entity"></a>entity |  A single entity to test.   |  `None` |
 | <a id="vhdl_test-entities"></a>entities |  A list of entities to test. If both `entity` and `entities` are provided, all are tested.   |  `[]` |
 | <a id="vhdl_test-tags"></a>tags |  A list of tags to apply to the generated test target (e.g., ["manual"]).   |  `[]` |


### PR DESCRIPTION
## Summary
Adds a `generics` map and a `data` attribute to `vhdl_test` (forwarded to `vhdl_elaborate`), so NVC testbenches can load firmware / init files via top-level generics. Resolves #101.

## What
- **`generics = {}`** — `dict[str,str]`, emitted as `-gNAME=VALUE` at the elaborate step.
- **`data = []`** — files staged into the elaborate action's inputs.
- **`$(location)`/`$(rootpath)` expansion** on generic *values* over `data`, so a generic can reference a build artifact's path.

Applied at *elaboration* because testbench memories are typically initialized in a signal initializer (`signal mem := load_mem(memfile)`) evaluated at elaboration time.

## Validation
In `filmil/a200t_examples`, `//boards/noelv/tool.nvc/boot:opensbi_nvc_boot` loads the OpenSBI `.mem` firmware into the NOEL-V testbench via `generics` + `data`; the design elaborates and the core executes the loaded firmware under NVC (cache-controller + PMP activity), vs the empty-firmware probe. Stardoc regenerated (`//internal:update`, `//build/nvc:update`).

## Follow-ups (not in this PR)
- Booting *large* firmware additionally needs NVC's elaborate-step `-H`/`-M` heap raised (the behavioral-memory init array is folded at elaboration) — a global NVC option the rule can't yet inject.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01BtpejRcfGU3fWf4KJk4fzd