### PR TITLE
docs: regenerate nvc/rules.md (fixes Tag and Release Test)

### DIFF
--- a/nvc/rules.md
+++ b/nvc/rules.md
@@ -78,7 +78,7 @@ Produces a waveform file (VCD) from a VHDL simulation run.
 <pre>
 load("@rules_nvc//nvc:rules.bzl", "vhdl_elaborate")
 
-vhdl_elaborate(<a href="#vhdl_elaborate-name">name</a>, <a href="#vhdl_elaborate-library">library</a>, <a href="#vhdl_elaborate-standard">standard</a>)
+vhdl_elaborate(<a href="#vhdl_elaborate-name">name</a>, <a href="#vhdl_elaborate-data">data</a>, <a href="#vhdl_elaborate-generics">generics</a>, <a href="#vhdl_elaborate-library">library</a>, <a href="#vhdl_elaborate-standard">standard</a>)
 </pre>
 
 Elaborates a VHDL design using NVC.
@@ -89,6 +89,8 @@ Elaborates a VHDL design using NVC.
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="vhdl_elaborate-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="vhdl_elaborate-data"></a>data |  Files made available to the elaboration action, e.g. memory init files referenced by a generic value.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="vhdl_elaborate-generics"></a>generics |  Top-level VHDL generics to set at elaboration, as a name -> value map (emitted as -gNAME=VALUE after the top unit).  Values undergo $(location)/$(rootpath) expansion over `data`.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
 | <a id="vhdl_elaborate-library"></a>library |  The `vhdl_library` target to elaborate.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
 | <a id="vhdl_elaborate-standard"></a>standard |  The VHDL standard to use for elaboration (e.g., '2019').   | String | optional |  `"2019"`  |
 
@@ -152,7 +154,7 @@ Simulates an elaborated VHDL design using NVC.
 <pre>
 load("@rules_nvc//nvc:rules.bzl", "vhdl_test")
 
-vhdl_test(<a href="#vhdl_test-name">name</a>, <a href="#vhdl_test-srcs">srcs</a>, <a href="#vhdl_test-deps">deps</a>, <a href="#vhdl_test-standard">standard</a>, <a href="#vhdl_test-args">args</a>, <a href="#vhdl_test-entity">entity</a>, <a href="#vhdl_test-entities">entities</a>, <a href="#vhdl_test-tags">tags</a>)
+vhdl_test(<a href="#vhdl_test-name">name</a>, <a href="#vhdl_test-srcs">srcs</a>, <a href="#vhdl_test-deps">deps</a>, <a href="#vhdl_test-standard">standard</a>, <a href="#vhdl_test-args">args</a>, <a href="#vhdl_test-generics">generics</a>, <a href="#vhdl_test-data">data</a>, <a href="#vhdl_test-entity">entity</a>, <a href="#vhdl_test-entities">entities</a>, <a href="#vhdl_test-tags">tags</a>)
 </pre>
 
 Defines a VHDL test.
@@ -171,6 +173,8 @@ execution steps into a single logical target.
 | <a id="vhdl_test-deps"></a>deps |  A list of `vhdl_library` targets that this test depends on.   |  none |
 | <a id="vhdl_test-standard"></a>standard |  The VHDL standard to use (e.g., "2008", "2019"). Defaults to "2019".   |  `"2019"` |
 | <a id="vhdl_test-args"></a>args |  A list of additional command-line arguments to pass to the NVC simulator.   |  `[]` |
+| <a id="vhdl_test-generics"></a>generics |  Top-level VHDL generics to set at elaboration, as a name -> value map (emitted as -gNAME=VALUE). Values undergo $(location)/$(rootpath) expansion over `data`, so a generic can reference a build artifact (e.g. a memory init file the testbench reads at elaboration time).   |  `{}` |
+| <a id="vhdl_test-data"></a>data |  Files made available to the elaboration action (e.g. the memory init files referenced by `generics`).   |  `[]` |
 | <a id="vhdl_test-entity"></a>entity |  A single entity to test.   |  `None` |
 | <a id="vhdl_test-entities"></a>entities |  A list of entities to test. If both `entity` and `entities` are provided, all are tested.   |  `[]` |
 | <a id="vhdl_test-tags"></a>tags |  A list of tags to apply to the generated test target (e.g., ["manual"]).   |  `[]` |


### PR DESCRIPTION
#102 regenerated `internal/*.md` and `build/nvc/rules.md` but missed `//nvc:update`, so `nvc/rules.md` was left stale. `//nvc:update_test` (the stardoc diff-test) then fails the **Test** step of the Tag and Release workflow ([run](https://github.com/filmil/bazel_rules_nvc/actions/runs/28516375819)).

This regenerates `nvc/rules.md` (`bazel run //nvc:update`). Verified all three doc diff-tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01BtpejRcfGU3fWf4KJk4fzd