### PR TITLE
Add vhdl_library analysis_opts attribute; -L dedupe; cfg=exec migration

### DIFF
--- a/integration/relaxed/BUILD.bazel
+++ b/integration/relaxed/BUILD.bazel
@@ -1,0 +1,29 @@
+load(
+    "@rules_nvc//build/nvc:rules.bzl",
+    "vhdl_elaborate",
+    "vhdl_library",
+    "vhdl_run",
+)
+
+# Demonstrates `analysis_opts`: this file only analyzes with `--relaxed`
+# under VHDL-2008 (it declares a shared variable of a non-protected type).
+vhdl_library(
+    name = "work",
+    srcs = [
+        "relaxed.vhdl",
+    ],
+    analysis_opts = ["--relaxed"],
+    entities = ["relaxed_top"],
+    standard = "2008",
+)
+
+vhdl_elaborate(
+    name = "relaxed_top",
+    library = ":work",
+    standard = "2008",
+)
+
+vhdl_run(
+    name = "sim",
+    entity = ":relaxed_top",
+)

--- a/integration/relaxed/relaxed.vhdl
+++ b/integration/relaxed/relaxed.vhdl
@@ -1,0 +1,19 @@
+-- Exercises the `analysis_opts` attribute of vhdl_library: a shared variable
+-- of a non-protected type is an error under strict VHDL-2000-and-later rules,
+-- but is accepted (with a warning) when analyzed with `nvc -a --relaxed`.
+-- Code bases written for the permissive defaults of commercial simulators
+-- (e.g. GRLIB) rely on this.
+
+entity relaxed_top is
+end entity relaxed_top;
+
+architecture test of relaxed_top is
+  shared variable counter : integer := 0;  -- requires --relaxed in VHDL >= 2000
+begin
+  process
+  begin
+    counter := counter + 1;
+    report "counter is " & integer'image(counter);
+    wait;
+  end process;
+end architecture test;

--- a/internal/produce_waveform.bzl
+++ b/internal/produce_waveform.bzl
@@ -45,7 +45,7 @@ produce_waveform = rule(
     attrs = {
         "simulation": attr.label(
             executable = True,
-            cfg = "host",
+            cfg = "exec",
             doc = "The simulation target (`vhdl_run`) to execute.",
         ),
         "data": attr.label_list(

--- a/internal/toolchain.bzl
+++ b/internal/toolchain.bzl
@@ -29,7 +29,7 @@ nvc_toolchain = rule(
   attrs = {
     "analyzer": attr.label(
         executable = True,
-        cfg = "host",
+        cfg = "exec",
         doc = "The NVC executable wrapper script.",
     ),
     "artifacts_dir": attr.label(

--- a/internal/verilog_library.bzl
+++ b/internal/verilog_library.bzl
@@ -129,7 +129,7 @@ verilog_library = rule(
         "_direct_wrapper": attr.label(
             default = _NVC_DIRECT_WRAPPER,
             executable = True,
-            cfg = "host",
+            cfg = "exec",
         ),
     },
     toolchains = [

--- a/internal/verilog_library.bzl
+++ b/internal/verilog_library.bzl
@@ -44,6 +44,8 @@ def _impl(ctx):
         all_libraries += vhdl_provider.libraries
         deps_hdrs_depset += [vhdl_provider.hdrs]
         for name, path in vhdl_provider.libraries:
+            if name in seen:
+                continue
             flag_libraries += ["-L", "{path}".format(path=path.path)]
             seen += [name]
         for include_dir in vhdl_provider.includes:

--- a/internal/vhdl_elaborate.bzl
+++ b/internal/vhdl_elaborate.bzl
@@ -110,7 +110,7 @@ vhdl_elaborate = rule(
         "_script": attr.label(
             default = _NVC_WRAPPER,
             executable = True,
-            cfg = "host",
+            cfg = "exec",
             doc = "Wrapper script to run NVC.",
         ),
         "standard": attr.string(

--- a/internal/vhdl_library.bzl
+++ b/internal/vhdl_library.bzl
@@ -71,7 +71,7 @@ def _vhdl_library(ctx):
             library_name,
           ),
           "-a",
-        ] + [f.path for f in srcs],
+        ] + ctx.attr.analysis_opts + [f.path for f in srcs],
         tools = [analyzer_x] + artifacts,
         # Only seems to work from bazel 6.0.0 on.
         #toolchain = _NVC_TOOLCHAIN_TYPE,
@@ -104,6 +104,11 @@ vhdl_library = rule(
         ),
         "entities": attr.string_list(
             doc = "A list of VHDL entities provided by this library.",
+        ),
+        "analysis_opts": attr.string_list(
+            doc = "Extra options passed to `nvc -a`, e.g. `[\"--relaxed\"]` " +
+                  "for code bases that need relaxed LRM rules (GRLIB, " +
+                  "vendor libraries).",
         ),
         "standard": attr.string(
             default = _VHDL_STANDARD_DEFAULT,

--- a/internal/vhdl_library.bzl
+++ b/internal/vhdl_library.bzl
@@ -46,6 +46,8 @@ def _vhdl_library(ctx):
         if hasattr(vhdl_provider, "vpi_plugins"):
             vpi_plugins.append(vhdl_provider.vpi_plugins)
         for name, path in vhdl_provider.libraries:
+            if name in seen:
+                continue
             flag_libraries += ["-L", "{path}".format(path=path.path)]
             seen += [name]
 

--- a/internal/vhdl_library.bzl
+++ b/internal/vhdl_library.bzl
@@ -123,7 +123,7 @@ vhdl_library = rule(
         "_direct_wrapper": attr.label(
             default = _NVC_DIRECT_WRAPPER,
             executable = True,
-            cfg = "host",
+            cfg = "exec",
         ),
     },
     toolchains = [

--- a/internal/vhdl_run.bzl
+++ b/internal/vhdl_run.bzl
@@ -111,7 +111,7 @@ vhdl_run = rule(
         "_script": attr.label(
             default = _NVC_WRAPPER,
             executable = True,
-            cfg = "host",
+            cfg = "exec",
             doc = "Wrapper script to run NVC.",
         ),
         "standard": attr.string(

--- a/internal/vhdl_test.bzl
+++ b/internal/vhdl_test.bzl
@@ -128,7 +128,7 @@ _vhdl_internal_test = rule(
         "_script": attr.label(
             default = _NVC_WRAPPER,
             executable = True,
-            cfg = "host",
+            cfg = "exec",
             doc = "Wrapper script to run NVC.",
         ),
         "standard": attr.string(

--- a/nvc/rules.md
+++ b/nvc/rules.md
@@ -102,7 +102,7 @@ Elaborates a VHDL design using NVC.
 <pre>
 load("@rules_nvc//nvc:rules.bzl", "vhdl_library")
 
-vhdl_library(<a href="#vhdl_library-name">name</a>, <a href="#vhdl_library-deps">deps</a>, <a href="#vhdl_library-srcs">srcs</a>, <a href="#vhdl_library-entities">entities</a>, <a href="#vhdl_library-library_name">library_name</a>, <a href="#vhdl_library-standard">standard</a>, <a href="#vhdl_library-vpi_plugins">vpi_plugins</a>)
+vhdl_library(<a href="#vhdl_library-name">name</a>, <a href="#vhdl_library-deps">deps</a>, <a href="#vhdl_library-srcs">srcs</a>, <a href="#vhdl_library-analysis_opts">analysis_opts</a>, <a href="#vhdl_library-entities">entities</a>, <a href="#vhdl_library-library_name">library_name</a>, <a href="#vhdl_library-standard">standard</a>, <a href="#vhdl_library-vpi_plugins">vpi_plugins</a>)
 </pre>
 
 Compiles VHDL source files into a library using NVC.
@@ -115,6 +115,7 @@ Compiles VHDL source files into a library using NVC.
 | <a id="vhdl_library-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
 | <a id="vhdl_library-deps"></a>deps |  A list of other `vhdl_library` targets that this library depends on.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="vhdl_library-srcs"></a>srcs |  A list of VHDL source files.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="vhdl_library-analysis_opts"></a>analysis_opts |  Extra options passed to `nvc -a`, e.g. `["--relaxed"]` for code bases that need relaxed LRM rules (GRLIB, vendor libraries).   | List of strings | optional |  `[]`  |
 | <a id="vhdl_library-entities"></a>entities |  A list of VHDL entities provided by this library.   | List of strings | optional |  `[]`  |
 | <a id="vhdl_library-library_name"></a>library_name |  If the target name is not appropriate as a library name, provide one here   | String | optional |  `""`  |
 | <a id="vhdl_library-standard"></a>standard |  The VHDL standard to use for compilation (e.g., '2008', '2019'). Defaults to '2019'.   | String | optional |  `"2019"`  |


### PR DESCRIPTION
Three independent, topical improvements, each in its own commit.

### 1. `feat(vhdl_library)`: add `analysis_opts` attribute
Adds an `analysis_opts` string_list to `vhdl_library`, appended verbatim to the `nvc -a` command line. This lets a target pass extra analysis flags — most importantly `--relaxed` — without patching the rules. Code bases written for the permissive defaults of commercial simulators (GRLIB and many vendor libraries) need `--relaxed` to analyze under NVC's stricter LRM enforcement.

- Regenerated `nvc/rules.md` via `bazel run //nvc:update`.
- New `integration/relaxed/` example: its source declares a shared variable of a non-protected type, which only analyzes with `--relaxed` under VHDL-2008 — so the example genuinely exercises the new attribute.

### 2. `fix`: skip duplicate `-L` library search paths
When a dependency graph reaches the same VHDL library through more than one path, the deps loop emitted a `-L <path>` flag per occurrence, bloating the analyzer command line (noticeable on deep graphs like GRLIB). A `seen` list was already accumulated but never consulted — this uses it to emit each search path once. Applied to both `vhdl_library` and `verilog_library`.

### 3. `chore`: migrate `cfg = "host"` → `cfg = "exec"`
`cfg = "host"` is deprecated in favor of `cfg = "exec"`; recent Bazel warns on it and the alias is slated for removal. Updates every tool-executable attribute across `internal/*.bzl` (`cosim.bzl` was already on `exec`).

Each change is isolated in its own commit so they can be reviewed, reverted, or cherry-picked independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M1ky3vnJW2YUp2Tkfm8F3V
