### PR TITLE
docs: regenerate vhdl_library docs for analysis_opts attribute

### DIFF
--- a/build/nvc/rules.md
+++ b/build/nvc/rules.md
@@ -157,7 +157,7 @@ Elaborates a VHDL design using NVC.
 <pre>
 load("@rules_nvc//build/nvc:rules.bzl", "vhdl_library")
 
-vhdl_library(<a href="#vhdl_library-name">name</a>, <a href="#vhdl_library-deps">deps</a>, <a href="#vhdl_library-srcs">srcs</a>, <a href="#vhdl_library-entities">entities</a>, <a href="#vhdl_library-library_name">library_name</a>, <a href="#vhdl_library-standard">standard</a>, <a href="#vhdl_library-vpi_plugins">vpi_plugins</a>)
+vhdl_library(<a href="#vhdl_library-name">name</a>, <a href="#vhdl_library-deps">deps</a>, <a href="#vhdl_library-srcs">srcs</a>, <a href="#vhdl_library-analysis_opts">analysis_opts</a>, <a href="#vhdl_library-entities">entities</a>, <a href="#vhdl_library-library_name">library_name</a>, <a href="#vhdl_library-standard">standard</a>, <a href="#vhdl_library-vpi_plugins">vpi_plugins</a>)
 </pre>
 
 Compiles VHDL source files into a library using NVC.
@@ -170,6 +170,7 @@ Compiles VHDL source files into a library using NVC.
 | <a id="vhdl_library-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
 | <a id="vhdl_library-deps"></a>deps |  A list of other `vhdl_library` targets that this library depends on.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="vhdl_library-srcs"></a>srcs |  A list of VHDL source files.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="vhdl_library-analysis_opts"></a>analysis_opts |  Extra options passed to `nvc -a`, e.g. `["--relaxed"]` for code bases that need relaxed LRM rules (GRLIB, vendor libraries).   | List of strings | optional |  `[]`  |
 | <a id="vhdl_library-entities"></a>entities |  A list of VHDL entities provided by this library.   | List of strings | optional |  `[]`  |
 | <a id="vhdl_library-library_name"></a>library_name |  If the target name is not appropriate as a library name, provide one here   | String | optional |  `""`  |
 | <a id="vhdl_library-standard"></a>standard |  The VHDL standard to use for compilation (e.g., '2008', '2019'). Defaults to '2019'.   | String | optional |  `"2019"`  |

--- a/integration/relaxed/BUILD.bazel
+++ b/integration/relaxed/BUILD.bazel
@@ -23,7 +23,14 @@ vhdl_elaborate(
     standard = "2008",
 )
 
+# standard must match the library/elaborate standard, otherwise `nvc -r`
+# aborts with a STD.STANDARD version conflict.
+# use_fst: relaxed_top has no traced signals (only a shared variable), so
+# nvc's VCD path (dump to a temporary FST, then convert) has nothing to open
+# and fails; FST is nvc's native format and dumps directly.
 vhdl_run(
     name = "sim",
     entity = ":relaxed_top",
+    standard = "2008",
+    use_fst = True,
 )

--- a/internal/vhdl_library.md
+++ b/internal/vhdl_library.md
@@ -9,7 +9,7 @@
 <pre>
 load("@rules_nvc//internal:vhdl_library.bzl", "vhdl_library")
 
-vhdl_library(<a href="#vhdl_library-name">name</a>, <a href="#vhdl_library-deps">deps</a>, <a href="#vhdl_library-srcs">srcs</a>, <a href="#vhdl_library-entities">entities</a>, <a href="#vhdl_library-library_name">library_name</a>, <a href="#vhdl_library-standard">standard</a>, <a href="#vhdl_library-vpi_plugins">vpi_plugins</a>)
+vhdl_library(<a href="#vhdl_library-name">name</a>, <a href="#vhdl_library-deps">deps</a>, <a href="#vhdl_library-srcs">srcs</a>, <a href="#vhdl_library-analysis_opts">analysis_opts</a>, <a href="#vhdl_library-entities">entities</a>, <a href="#vhdl_library-library_name">library_name</a>, <a href="#vhdl_library-standard">standard</a>, <a href="#vhdl_library-vpi_plugins">vpi_plugins</a>)
 </pre>
 
 Compiles VHDL source files into a library using NVC.
@@ -22,6 +22,7 @@ Compiles VHDL source files into a library using NVC.
 | <a id="vhdl_library-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
 | <a id="vhdl_library-deps"></a>deps |  A list of other `vhdl_library` targets that this library depends on.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="vhdl_library-srcs"></a>srcs |  A list of VHDL source files.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="vhdl_library-analysis_opts"></a>analysis_opts |  Extra options passed to `nvc -a`, e.g. `["--relaxed"]` for code bases that need relaxed LRM rules (GRLIB, vendor libraries).   | List of strings | optional |  `[]`  |
 | <a id="vhdl_library-entities"></a>entities |  A list of VHDL entities provided by this library.   | List of strings | optional |  `[]`  |
 | <a id="vhdl_library-library_name"></a>library_name |  If the target name is not appropriate as a library name, provide one here   | String | optional |  `""`  |
 | <a id="vhdl_library-standard"></a>standard |  The VHDL standard to use for compilation (e.g., '2008', '2019'). Defaults to '2019'.   | String | optional |  `"2019"`  |


### PR DESCRIPTION
## Summary

Fixes the CI failure in [run 28687893170](https://github.com/filmil/bazel_rules_nvc/actions/runs/28687893170/job/85083804684), plus a second failure it was masking.

### 1. Stale generated docs (original failure)

The `analysis_opts` attribute added to `vhdl_library` in 625db55 was not accompanied by a regeneration of the stardoc-generated documentation, so the checked-in docs no longer matched their generated output and the `write_source_files` staleness tests failed:

- `//build/nvc:update_1_test` (guards `build/nvc/rules.md`)
- `//internal:update_9_test` (guards `internal/vhdl_library.md`)

Regenerated both via `bazel run //build/nvc:update` and `bazel run //internal:update`.

### 2. Broken `relaxed` integration test (unmasked once #1 passed)

The `cd integration && bazel build //... && bazel test //...` step failed at `//relaxed:sim`, which was previously hidden behind the earlier `bazel test //...` failure. Two problems in `integration/relaxed/BUILD.bazel`:

- The `vhdl_run` target inherited the default `standard` (2019) while the library/elaborate use 2008, so `nvc -r` aborted with a `STD.STANDARD` version conflict. Pinned the run to `standard = "2008"`.
- `relaxed_top` has no traced signals (only a shared variable), so nvc's VCD path (dump to a temporary FST, then convert) had nothing to open and died with `fstReaderOpen failed for temporary FST file`. Switched to `use_fst = True` — nvc's native format, which needs no conversion step.

## Testing

- Main workspace: `bazel test //...` — 18/18 pass.
- Integration workspace: `bazel build //... && bazel test //...` — build clean, 8/8 tests pass, `//relaxed:sim` produces `sim.fst`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)